### PR TITLE
(EXAMPLE) Script for converting from Jekyll

### DIFF
--- a/repo-scripts/convert-from-jekyll/convert.js
+++ b/repo-scripts/convert-from-jekyll/convert.js
@@ -1,0 +1,98 @@
+// A quick-and-dirty script to assist in converting markdown files from our
+// old Jekyll sites to files ready for Docusaurus.
+
+const glob = require('glob');
+const path = require('path');
+const fs = require('fs');
+
+const argv = process.argv.slice(2);
+const folder = argv[0];
+
+const files = glob.sync(`${folder}/**/*.md`);
+
+for (let file of files) {
+    console.log(file);
+    convert(file);
+    console.log();
+}
+
+function convert(file) {
+    let content = fs.readFileSync(file, 'utf8');
+    content = replaceJekyllLinks(content);
+    content = cleanFrontMatter(content);
+    content = convertStyles(content);
+    fs.writeFileSync(file, content, 'utf8');
+}
+
+// Replace Liquid-style links like:
+//
+//   [help]({% link pages/help.md %})
+//
+// Into standard relative path links:
+//
+//   [help](../help)
+//
+function replaceJekyllLinks(content) {
+    return content.replace(/\{% link pages\/(.+?)\.md %\}/g, (match, link) => {
+        link = `docs/${link}`;
+        link = path.relative(path.join(file, '..'), link);
+        return link;
+    });
+}
+
+// Replace or delete common frontmatter elements that aren't
+// supported by Docusaurus.
+//
+function cleanFrontMatter(content) {
+    let lines = content.split(/\r?\n/);
+    let frontMatterStarted = false;
+
+    for (let i = 0; i < lines.length; i++) {
+        let line = lines[i];
+
+        if (line.startsWith('---')) {
+            if (frontMatterStarted) break;
+            frontMatterStarted = true;
+        } else if (line.startsWith('navigation_source:')) {
+            lines.splice(i--, 1);
+        } else if (line.startsWith('layout:')) {
+            lines.splice(i--, 1);
+        }
+    }
+
+    return lines.join('\n');
+}
+
+// Convert "HTML" styles attributes into "MDX" (React) styles attributes.
+//
+// Works for most simple inline styles but it is regex-based, so review
+// the output for issues. This is intended only as a first-pass; ideally
+// remaining styles should be sucked out into custom.css or into a
+// React component with styles.
+//
+// Input:
+//
+//   <div style="width:300px; background-color: blue">
+//
+// Output:
+//
+//   <div style={{ width: "300px", backgroundColor: "blue" }}>
+//
+function convertStyles(content) {
+    return content.replace(/style=(".+?")/g, (match, style) => {
+        let components = style.slice(1, -1).split(/;\W*/);
+        let obj = {};
+
+        for (let component of components) {
+            let [key, value] = component.split(/:\W*/);
+            if (!key || !value) continue;
+            key = key.replace(/(-[a-z])/g, (match, slug) => {
+                return slug[1].toUpperCase();
+            });
+            obj[key] = value;
+        }
+
+        let props = Object.entries(obj).map(([key, value]) => `${key}: "${value}"`).join(', ');
+        return `style={{ ${props} }}`;
+    });
+}

--- a/repo-scripts/convert-from-jekyll/package-lock.json
+++ b/repo-scripts/convert-from-jekyll/package-lock.json
@@ -1,0 +1,85 @@
+{
+  "name": "convert-from-jekyll",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/repo-scripts/convert-from-jekyll/package.json
+++ b/repo-scripts/convert-from-jekyll/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "convert-from-jekyll",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "glob": "^7.2.0"
+  }
+}


### PR DESCRIPTION
### SUMMARY

This is a script I use to take a pile of markdown files from an existing Jekyll repo and get them loadable by Docusaurus.

I don't intend to merge this, because (1) it's very rough, and (2) it has limited usefulness after we've converted existing sites to Docusaurus.  But I'm putting it up in a PR, it may be a helpful reference for people while the conversions are ongoing.