### PR TITLE
Links between sites are now specified using cross-site prefixes

### DIFF
--- a/tools/site-config/src/index.js
+++ b/tools/site-config/src/index.js
@@ -64,16 +64,24 @@ function getTargetOrg() {
 function getSiteConfig(packageName) {
     const target = getTargetOrg();
 
+    const sitePrefixes = {
+        '@api-extractor': 'https://api-extractor.com',
+        '@rushjs': 'https://rushjs.io',
+        '@tsdoc': 'https://tsdoc.org'
+    };
+
     switch (target.target) {
         case 'local':
             return {
                 ...target,
+                sitePrefixes,
                 configOverrides: {
                 }
             };
         case 'fork':
             return {
                 ...target,
+                sitePrefixes,
                 configOverrides: {
                     baseUrl: `/rushstack-websites/${packageName}/`,
                     organizationName: target.org
@@ -82,6 +90,7 @@ function getSiteConfig(packageName) {
         case 'prod':
             return {
                 ...target,
+                sitePrefixes,
                 configOverrides: {
                 }
             };

--- a/websites/rushstack.io/custom.config.js
+++ b/websites/rushstack.io/custom.config.js
@@ -1,5 +1,16 @@
 // Custom Configuration Options
 
+// Set the environment variable SKIP_API_DOCS=1 to skip Rush Stack API docs.
+//
+// Specifically:
+//   - Avoid generating the files in docs/api/**
+//   - Do not include the data/api_nav.json sidebar file
+//   - Suppress the "API" top navbar item
+//
+// This setting can be helpful for quick iterations on site config, as it
+// drops the startup time of "rushx start" significantly.
+const SKIP_API_DOCS = process.env.SKIP_API_DOCS === '1';
+
 module.exports = {
-    SKIP_API_DOCS: process.env.SKIP_API_DOCS === '1'
+    SKIP_API_DOCS
 };

--- a/websites/rushstack.io/docs/contributing/get_started.md
+++ b/websites/rushstack.io/docs/contributing/get_started.md
@@ -9,8 +9,8 @@ The Rush Stack projects are all developed in the **rushstack** monorepo on GitHu
 For documentation fixes, each website has its own GitHub repo:
 
 - Rush Stack website: [https://github.com/microsoft/rushstack.io-website](https://github.com/microsoft/rushstack.io-website)
-- [Rush](https://rushjs.io/) website: [https://github.com/microsoft/rushjs.io-website](https://github.com/microsoft/rushjs.io-website)
-- [API Extractor](https://api-extractor.com/) website: [https://github.com/microsoft/api-extractor.com-website](https://github.com/microsoft/api-extractor.com-website)
+- [Rush](@rushjs/) website: [https://github.com/microsoft/rushjs.io-website](https://github.com/microsoft/rushjs.io-website)
+- [API Extractor](@api-extractor/) website: [https://github.com/microsoft/api-extractor.com-website](https://github.com/microsoft/api-extractor.com-website)
 
 
 ## Setting up your machine
@@ -52,7 +52,7 @@ C:\Repos\rushstack\libraries\rush-core-library>rushx build
 ```
 
 **Important**: You generally should **not** use commands like `npm install` in a Rush repo.  See the
-[Rush documentation](https://rushjs.io/pages/developer/new_developer/) for more information about this tool.
+[Rush documentation](@rushjs/pages/developer/new_developer/) for more information about this tool.
 
 ## Submitting a Pull Request
 
@@ -62,7 +62,7 @@ We welcome contributions!  To submit a feature for one of the **rushstack** proj
 2. Create a Git branch and commit your changes.
 3. If you modified any package.json files, run `rush update` to make sure your **package-lock.json** file is up to date.
    Commit any changes made to that file.
-4. Before creating your PR, run `rush change`; if prompted, [enter a change log message](https://rushjs.io/pages/best_practices/change_logs/), and commit the files that get created.
+4. Before creating your PR, run `rush change`; if prompted, [enter a change log message](@rushjs/pages/best_practices/change_logs/), and commit the files that get created.
 5. Create a [pull request](https://help.github.com/articles/creating-a-pull-request/)
 6. If your PR primarily affects a single project, add the project name as a prefix to your PR title.  For example: "**[api-extractor] Added a new API feature**" or "**[node-core-libary] Fixed a bug in the library**".
 

--- a/websites/rushstack.io/docs/heft/architecture.md
+++ b/websites/rushstack.io/docs/heft/architecture.md
@@ -16,5 +16,5 @@ The following concepts are important for understanding Heft's design:
 
 &nbsp;
 > **Future plans:** Today Rush commands can only invoke Heft actions.  However, in the future we want to implement a "multiphase build" feature that will enable Rush to orchestrate more granular steps of work.  For example, once a library dependency has compiled its output, Rush could start building the application before the library finishes running its unit tests.  This feature will bring some additional jargon:
-> - **command** - A monorepo command-line action as defined globally in [command-line.json](https://rushjs.io/pages/configs/command-line_json/).
+> - **command** - A monorepo command-line action as defined globally in [command-line.json](@rushjs/pages/configs/command-line_json/).
 > - **phase** - This is similar to Heft's "stage", except that phases will be defined globally so that Rush can model their dependency relationships.

--- a/websites/rushstack.io/docs/heft/overview.md
+++ b/websites/rushstack.io/docs/heft/overview.md
@@ -17,7 +17,7 @@ and API Extractor. You can use it to build web applications, Node.js services, c
 and more. Heft builds all your JavaScript projects the same way: A way that works.
 
 Heft is typically launched by the `"build"` action from a **package.json** file. It's designed for use in
-a monorepo with potentially hundreds of projects, where the [Rush](https://rushjs.io/) orchestrator invokes
+a monorepo with potentially hundreds of projects, where the [Rush](@rushjs/) orchestrator invokes
 a `"build"` action separately in each project folder. In this situation, everything must execute as fast as possible.
 Special purpose scripts become a headache to maintain, so it's better to replace them with a reusable engine that's
 driven by config files. In a large repo, you'll want to minimize duplication of these config files across projects.

--- a/websites/rushstack.io/docs/heft_configs/api-extractor-task_json.md
+++ b/websites/rushstack.io/docs/heft_configs/api-extractor-task_json.md
@@ -43,4 +43,4 @@ title: api-extractor-task.json
 ## See also
 
 - [api-extractor](../heft_tasks/api-extractor) task
-- [API Extractor](https://api-extractor.com/) website
+- [API Extractor](@api-extractor/) website

--- a/websites/rushstack.io/docs/heft_tasks/api-extractor.md
+++ b/websites/rushstack.io/docs/heft_tasks/api-extractor.md
@@ -2,7 +2,7 @@
 title: '"api-extractor" task'
 ---
 
-This task invokes the [API Extractor](https://api-extractor.com/) tool which reads TypeScript declarations (.d.ts files)
+This task invokes the [API Extractor](@api-extractor/) tool which reads TypeScript declarations (.d.ts files)
 as inputs and produces three types of outputs:
 
 **1. API Report** - API Extractor can trace all exports from your project's main entry point and generate
@@ -16,7 +16,7 @@ JSON file contains the extracted type signatures and doc comments.  The **api-do
 can use these files to generate an API reference website, or you can use them as inputs for a custom documentation
 pipeline.
 
-See the [API Extractor documentation](https://api-extractor.com/pages/overview/intro/) for details about how it works.
+See the [API Extractor documentation](@api-extractor/pages/overview/intro/) for details about how it works.
 
 
 ## When to use it
@@ -37,6 +37,6 @@ Alternatively, you can avoid this dependency by loading it from a rig, as descri
 
 ## Configuration
 
-Heft looks for API Extractor's config file [config/api-extractor.json](https://api-extractor.com/pages/commands/config_file/). This file can be created by invoking the [api-extractor init](https://api-extractor.com/pages/commands/api-extractor_init/) command.  This file is [riggable](../heft/rig_packages).
+Heft looks for API Extractor's config file [config/api-extractor.json](@api-extractor/pages/commands/config_file/). This file can be created by invoking the [api-extractor init](@api-extractor/pages/commands/api-extractor_init/) command.  This file is [riggable](../heft/rig_packages).
 
 For advanced scenarios, the optional [api-extractor-task.json](../heft_configs/api-extractor-task_json) config file provides some additional Heft-specific settings.

--- a/websites/rushstack.io/docs/heft_tasks/eslint.md
+++ b/websites/rushstack.io/docs/heft_tasks/eslint.md
@@ -9,7 +9,7 @@ This task invokes the [ESLint](https://eslint.org/) tool which reports errors ab
 
 ESLint fits together with several other tools as part of Rush Stack's recommended strategy for code validation:
 
-- [Prettier](https://rushjs.io/pages/maintainer/enabling_prettier/): This tool manages trivial syntax aspects such as spaces, commas, and semicolons. Because these aspects normally don't affect code semantics, we never bother the developer with error messages about it, nor is it part of the build.  Instead, Prettier reformats the code automatically via a `git commit` hook.  To se this up, see the [Enabling Prettier](https://rushjs.io/pages/maintainer/enabling_prettier/) tutorial on the Rush website.
+- [Prettier](@rushjs/pages/maintainer/enabling_prettier/): This tool manages trivial syntax aspects such as spaces, commas, and semicolons. Because these aspects normally don't affect code semantics, we never bother the developer with error messages about it, nor is it part of the build.  Instead, Prettier reformats the code automatically via a `git commit` hook.  To se this up, see the [Enabling Prettier](@rushjs/pages/maintainer/enabling_prettier/) tutorial on the Rush website.
 
 - [TypeScript](../heft_tasks/typescript): The TypeScript compiler performs sophisticated type checking and semantic analysis that is the most important safeguard for program correctness.
 

--- a/websites/rushstack.io/docs/heft_tutorials/adding_tasks.md
+++ b/websites/rushstack.io/docs/heft_tutorials/adding_tasks.md
@@ -11,8 +11,9 @@ Continuing our tutorial, let's enable the two most common tasks: [Jest](../heft_
 and [ESlint](../heft_tasks/eslint).
 
 ## Adding unit tests to your project
+1
+1. First, we need to install the TypeScript typings for Jest.  These steps continue the **my-app** project from the [Getting started with Heft](../heft_tutorials/getting_started) article.  Recall that this project is not using Rush yet, so we will invoke PNPM directly to add the dependency to our **package.json** file (instead of using [rush add](@rushjs/pages/commands/rush_add/)):
 
-1. First, we need to install the TypeScript typings for Jest.  These steps continue the **my-app** project from the [Getting started with Heft](../heft_tutorials/getting_started) article.  Recall that this project is not using Rush yet, so we will invoke PNPM directly to add the dependency to our **package.json** file (instead of using [rush add](https://rushjs.io/pages/commands/rush_add/)):
 
     ```shell
     $ cd my-app
@@ -165,7 +166,7 @@ That's it for setting up Jest!  Further information, including instructions for 
     ```
 
 4.  The `@rushstack/eslint-config` ruleset is designed to work together with the Prettier code formatter.
-    To set that up, see the [Enabling Prettier](https://rushjs.io/pages/maintainer/enabling_prettier/) article
+    To set that up, see the [Enabling Prettier](@rushjs/pages/maintainer/enabling_prettier/) article
     on the Rush website.
 
 That's it for ESLint!  More detail can be found in the [eslint task](../heft_tasks/eslint) reference.

--- a/websites/rushstack.io/docs/heft_tutorials/heft_and_rush.md
+++ b/websites/rushstack.io/docs/heft_tutorials/heft_and_rush.md
@@ -6,7 +6,7 @@ The [Getting started with Heft](../heft_tutorials/getting_started) tutorial show
 
 ## How Heft gets invoked
 
-If you're new to Rush, the [maintainer tutorials](https://rushjs.io/pages/maintainer/setup_new_repo/) explain the basics of setting up a new repo.  Heft takes over when Rush invokes the `"build"` script in a Rush project folder.  In our sample project from the tutorial, the script looked like this:
+If you're new to Rush, the [maintainer tutorials](@rushjs/pages/maintainer/setup_new_repo/) explain the basics of setting up a new repo.  Heft takes over when Rush invokes the `"build"` script in a Rush project folder.  In our sample project from the tutorial, the script looked like this:
 
 **&lt;project folder&gt;/package.json**
 ```

--- a/websites/rushstack.io/docs/index.md
+++ b/websites/rushstack.io/docs/index.md
@@ -18,10 +18,10 @@ Although various pieces of this work have been underway for years, we're now bri
 
 These major tools are developed under the **Rush Stack** umbrella:
 
-- [Rush](https://rushjs.io/): the scalable monorepo build orchestrator
+- [Rush](@rushjs/): the scalable monorepo build orchestrator
 - [Heft](heft/overview): an extensible build system that interfaces with Rush
-- [API Extractor](https://api-extractor.com/): coordinates API reviews for library packages, and generates .d.ts rollups
-- [API Documenter](https://api-extractor.com/pages/setup/generating_docs/): generates your API documentation website
+- [API Extractor](@api-extractor/): coordinates API reviews for library packages, and generates .d.ts rollups
+- [API Documenter](@api-extractor/pages/setup/generating_docs/): generates your API documentation website
 - [@<!---->rushstack/eslint-config](https://www.npmjs.com/package/@rushstack/eslint-config): our standardized
   ESLint rule set, specifically designed for large scale TypeScript monorepos
 - [@<!---->rushstack/eslint-plugin-packlets](https://www.npmjs.com/package/@rushstack/eslint-plugin-packlets):
@@ -44,7 +44,7 @@ The projects are built on a common framework of reusable library packages, which
 
 ## What's the relationship to Rush?
 
-The "Rush Stack" components are optional extras that you can use with [Rush](https://rushjs.io/).
+The "Rush Stack" components are optional extras that you can use with [Rush](@rushjs/).
 
 As a **build orchestrator,** Rush's job is to:
 - Ensure deterministic and reliable package installations (using Yarn, PNPM, or NPM)

--- a/websites/rushstack.io/docs/overview/roadmap.md
+++ b/websites/rushstack.io/docs/overview/roadmap.md
@@ -18,9 +18,9 @@ These milestones were completed recently:
 - Optimize Rush startup time, adding a new tool [@rushstack/rundown](https://www.npmjs.com/package/@rushstack/rundown)
 - Redesign the "rush build" collator, based around a new [@rushstack/terminal](https://www.npmjs.com/package/@rushstack/terminal) model
 - Introduce a model for [rig packages](https://www.npmjs.com/package/@rushstack/rig-package)
-- Move the TSDoc project documentation to a dedicated website [https://tsdoc.org/](https://tsdoc.org/)
-- Get the Rush [build cache](https://rushjs.io/pages/maintainer/build_cache/) feature released and documented
-- [Artifactory integration](https://rushjs.io/pages/maintainer/npm_registry_auth/)  for Rush
+- Move the TSDoc project documentation to a dedicated website [https://tsdoc.org/](@tsdoc/)
+- Get the Rush [build cache](@rushjs/pages/maintainer/build_cache/) feature released and documented
+- [Artifactory integration](@rushjs/pages/maintainer/npm_registry_auth/)  for Rush
 - Merge API Extractor to support `import * as ___ from "___";` namespaces ([issue #1029](https://github.com/microsoft/rushstack/issues/1029))
 - Merge API Extractor to support `import()` type expressions ([issue #1050](https://github.com/microsoft/rushstack/issues/1050))
 - Start a new [@rushstack/eslint-plugin-security](https://www.npmjs.com/package/@rushstack/eslint-plugin-security) package
@@ -40,7 +40,7 @@ a particular feature will get implemented.  That said, here's some areas which p
 - Set up a [rushstack-samples](https://github.com/microsoft/rushstack-samples/) repo with fully worked out projects
   illustrating realistic usage patterns
 - Share samples for using ReactNative with Rush+PNPM
-- [Multi-project watch mode](https://rushjs.io/pages/advanced/watch_mode/) for Rush
+- [Multi-project watch mode](@rushjs/pages/advanced/watch_mode/) for Rush
 - Working towards a 1.0 release of Heft, to stabilize the config file and plugin API contracts
 
 

--- a/websites/rushstack.io/docusaurus.config.js
+++ b/websites/rushstack.io/docusaurus.config.js
@@ -4,7 +4,7 @@
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
-const { SKIP_API_DOCS } = require('./custom.config.js');
+const { SKIP_API_DOCS, SITE_PREFIXES } = require('./custom.config.js');
 
 const { getSiteConfig } = require('site-config');
 const siteConfig = getSiteConfig(require('./package.json').name);
@@ -41,8 +41,16 @@ const config = {
           editUrl: 'https://github.com/microsoft/rushstack.io-website/',
           remarkPlugins: [
             [
+              require('./src/remark/remark-cross-site-link-plugin'),
+              {
+                prefixes: siteConfig.sitePrefixes
+              }
+            ],
+            [
               require('./src/remark/remark-canonical-link-plugin'),
-              { prefix: 'https://rushstack.io/' }
+              {
+                prefix: 'https://rushstack.io/'
+              }
             ]
           ],
           rehypePlugins: [

--- a/websites/rushstack.io/src/remark/remark-cross-site-link-plugin.js
+++ b/websites/rushstack.io/src/remark/remark-cross-site-link-plugin.js
@@ -1,0 +1,71 @@
+const visit = require('unist-util-visit');
+
+/**
+ * This plugin runs after the markdown file has been parsed and turned into an AST,
+ * but before it is run through rehype (which turns the AST into HTML).
+ *
+ * The `prefixes` object passed in options provides the site prefixes to replace
+ * in markdown links and the value to replace them with.
+ *
+ * For example, the following options config:
+ *
+ *   {
+ *     prefixes: {
+ *       '@rushjs': 'https://rushjs.io'
+ *     }
+ *   }
+ *
+ * Will turn this markdown link:
+ *
+ *   [Check out Rush!](@rushjs/)
+ *
+ * Into this:
+ *
+ *   [Check out Rush!](https://rushjs.io/)
+ *
+ * Any site prefixes discovered in markdown files that aren't included in the `prefixes`
+ * object will throw an error.
+ *
+ * Note that links to docs in *this site* should always be relative paths within
+ * the docs folder, for example:
+ *
+ *   [Another page](../overview/getting_started)
+ *
+ * Links to docs on *other sites* should use the appropriate prefix marker and
+ * then the expected website URI:
+ *
+ *   [A page on another site](@api-extractor/pages/overview/getting_started)
+ *
+ * Finally, if the need arises to use Docusaurus' built-in @site prefix, you
+ * should use the PRE-BUILD path of the file in the project folder:
+ *
+ *   [Link to raw markdown file](@site/docs/overview/getting_started.md)
+ *
+ */
+module.exports = (options) => {
+  const prefixes = options.prefixes;
+
+  const transformer = async (ast) => {
+    visit(ast, 'link', (node) => {
+      if (node.url && node.url.startsWith('@')) {
+        // "@site" is a Docusaurus built-in, so we won't touch it
+        if (node.url.startsWith('@site')) return;
+
+        let found = false;
+
+        for (let prefix of Object.keys(prefixes)) {
+          if (node.url.startsWith(prefix)) {
+            found = true;
+            node.url = prefixes[prefix] + node.url.slice(prefix.length);
+            break;
+          }
+        }
+
+        if (!found) {
+          throw new Error(`Link with url '${node.url}' has unknown prefix (expected one of ${JSON.stringify(Object.keys(prefixes))})`);
+        }
+      }
+    });
+  };
+  return transformer;
+};

--- a/websites/rushstack.io/static/CNAME
+++ b/websites/rushstack.io/static/CNAME
@@ -1,0 +1,1 @@
+rushstack.io


### PR DESCRIPTION
### SUMMARY

Introduce a scheme for managing "cross-site links".

Docusaurus already has the special prefix `@site` for referring to the root of your Docusaurus project, so following that approach, we use site prefixes like `@rushjs` and `@api-extractor` to indicate other documentation sites that will eventually be part of the websites monorepo.

Because none of the other websites are hosted inside the monorepo yet, the initial set of `sitePrefixes` is the same for both `local`, `fork`, and `prod` targets; once additional sites are hosted, that will change for the non-prod targets.

The link replacement is done by a new `remark` plugin, which is passed in the set of possible site prefixes in its options object.

Eventually, the fact that we have a special strategy for specifying cross-site links should allow us to write a detailed link checker that understands the difference between "in-site links", "cross-site links", and "external" web site links.