### PR TITLE
Override canonical links for forked pages

### DIFF
--- a/websites/rushstack.io/docusaurus.config.js
+++ b/websites/rushstack.io/docusaurus.config.js
@@ -39,6 +39,12 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl: 'https://github.com/microsoft/rushstack.io-website/',
+          remarkPlugins: [
+            [
+              require('./src/remark/remark-canonical-link-plugin'),
+              { prefix: 'https://rushstack.io/' }
+            ]
+          ],
           rehypePlugins: [
             require('./src/rehype/rehype-headerless-table-plugin')
           ],

--- a/websites/rushstack.io/src/remark/remark-canonical-link-plugin.js
+++ b/websites/rushstack.io/src/remark/remark-canonical-link-plugin.js
@@ -26,7 +26,7 @@ module.exports = (options) => {
   }
 
   const transformer = async (ast, file) => {
-    if (file.history && file.history[0].match(/docs\/(.+)\.md/)) {
+    if (file.history && file.history[0] && file.history[0].match(/docs\/(.+)\.md/)) {
       const page = RegExp.$1;
       const canonicalUrl = `${prefix}pages/${page}/`;
       ast.children.unshift({

--- a/websites/rushstack.io/src/remark/remark-canonical-link-plugin.js
+++ b/websites/rushstack.io/src/remark/remark-canonical-link-plugin.js
@@ -1,0 +1,40 @@
+/**
+ * This plugin runs after the markdown file has been parsed and turned into an AST,
+ * but before it is run through rehype (which turns the AST into HTML).
+ *
+ * The `prefix` string passed in options provides the canonical URL prefix.
+ * Unlike the website URL configured in the Docusaurus config, this prefix doesn't
+ * rely on TARGET, because even for a deployed fork we want the canonical links
+ * pointing at the "real" production website.
+ *
+ * For example, the following options config:
+ *
+ *   {
+ *     prefix: 'https://rushstack.io/'
+ *   }
+ *
+ * Will add the following node to the `/docs/banana.md` page:
+ *
+ *   <head><link rel="canonical" href="https://rushstack.io/pages/banana" /></head>
+ *
+ */
+module.exports = (options) => {
+  const prefix = options.prefix;
+
+  if (!prefix || !prefix.endsWith('/')) {
+    throw new Error(`Invalid prefix '${prefix}' - expected a URL prefix ending with a slash (/)`);
+  }
+
+  const transformer = async (ast, file) => {
+    if (file.history && file.history[0].match(/docs\/(.+)\.md/)) {
+      const page = RegExp.$1;
+      const canonicalUrl = `${prefix}pages/${page}/`;
+      ast.children.unshift({
+        type: 'jsx',
+        value: `<head><link rel="canonical" href="${canonicalUrl}" /></head>`
+      });
+    }
+  };
+
+  return transformer;
+};


### PR DESCRIPTION
### SUMMARY

Insert a new "canonical" link for all pages in the `/doc` folder.

Technically, this inserts a new request for a link that is passed to the `react-helmet` plugin, which is smart enough to then override the _default_ canonical link that Docusaurus normally provides.

(It's standard to have a canonical link even to the same page, because this ensures that e.g. `/getting_started` and `/getting_started/` both resolve the same traffic.  In our case, we want this link to lead to the "real" rushstack site, even if the site being crawled is a deployed fork on GitHub Pages.)

Example of the new canonical link in action (use console to view meta tags): https://elliot-nelson.github.io/rushstack-websites/rushstack.io/pages/heft_tutorials/getting_started/

> _Note_: for now, this plugin is relatively simple.  We may need to make it a bit smarter if we add versioning and/or translated pages in the future, but if necessary we can revisit when that time comes.