### PR TITLE
Style Improvements

### DIFF
--- a/websites/rushstack.io/docusaurus.config.js
+++ b/websites/rushstack.io/docusaurus.config.js
@@ -74,10 +74,10 @@ const config = {
         },
         items: [
           {
-            type: 'doc',
-            docId: 'index',
+            to: 'pages/index',
             position: 'right',
             label: 'Docs',
+            activeBaseRegex: 'pages/(?!help/support)(?!contributing/get_started)(?!news)(?!shop)'
           },
           ...(SKIP_API_DOCS ? [] : [
             {
@@ -100,16 +100,16 @@ const config = {
             label: 'News',
           },
           {
-            type: 'doc',
-            docId: 'contributing/get_started',
+            to: 'pages/contributing/get_started',
             position: 'right',
             label: 'GitHub',
+            activeBasePath: 'pages/contributing/get_started'
           },
           {
-            type: 'doc',
-            docId: 'help/support',
+            to: 'pages/help/support',
             position: 'right',
             label: 'Help',
+            activeBasePath: 'pages/help/support'
           }
         ],
       },

--- a/websites/rushstack.io/src/css/custom.css
+++ b/websites/rushstack.io/src/css/custom.css
@@ -31,9 +31,7 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   /*
    * Rush Stack Customization - Infima style overrides
    */
-  --ifm-navbar-background-color: rgb(240, 240, 240);
   --ifm-navbar-height: 4rem;
-  --docsearch-searchbox-background: rgb(255, 0, 255);
 
   /*
    * Generated using https://docusaurus.io/docs/styling-layout, with the Primary Color
@@ -54,20 +52,36 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
  * the "lighter" version of rushstack orange above (cc6b49).
  */
 html[data-theme='dark'] {
-  --ifm-color-primary: #cc6b49;
-  --ifm-color-primary-dark: #c35b37;
-  --ifm-color-primary-darker: #b85634;
-  --ifm-color-primary-darkest: #97472a;
-  --ifm-color-primary-light: #d27d5f;
-  --ifm-color-primary-lighter: #d58569;
-  --ifm-color-primary-lightest: #dea08a;
+  --ifm-color-primary: #d58569;
+  --ifm-color-primary-dark: #ce7150;
+  --ifm-color-primary-darker: #cb6744;
+  --ifm-color-primary-darkest: #ae5131;
+  --ifm-color-primary-light: #dc9982;
+  --ifm-color-primary-lighter: #dfa38e;
+  --ifm-color-primary-lightest: #eac2b4;
 }
 
 /*
- * Rush Stack Customization - Search bar
+ * Top Nav
  */
-.DocSearch-Button {
-  border-radius: 2px;
+nav.navbar {
+  background: rgb(240, 240, 240);
+}
+html[data-theme='dark'] nav.navbar {
+  background: rgb(48, 48, 48);
+}
+
+/*
+ * Rush Stack Customization - Search button
+ */
+button.DocSearch-Button {
+  border-radius: 4px;
+  border: 1px solid #c0c0c0;
+  background: #ffffff;
+}
+html[data-theme='dark'] button.DocSearch-Button {
+  background: rgb(25, 25, 25);
+  border: 1px solid rgb(64, 64, 64);
 }
 
 /*

--- a/websites/rushstack.io/src/css/custom.css
+++ b/websites/rushstack.io/src/css/custom.css
@@ -140,8 +140,8 @@ blockquote {
   border-bottom-width: 1px;
   border-left-width: 6pt;
   border-radius: 4pt;
-  background-color: rgb(248, 248, 248);
+  background-color: rgb(253, 248, 247);
 }
 html[data-theme='dark'] blockquote {
-  background-color: rgb(32, 32, 32);
+  background-color: rgb(37, 32, 31);
 }

--- a/websites/rushstack.io/src/css/custom.css
+++ b/websites/rushstack.io/src/css/custom.css
@@ -32,6 +32,7 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
    * Rush Stack Customization - Infima style overrides
    */
   --ifm-navbar-height: 4rem;
+  --ifm-heading-font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
   /*
    * Generated using https://docusaurus.io/docs/styling-layout, with the Primary Color
@@ -44,6 +45,8 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   --ifm-color-primary-light: #c96440;
   --ifm-color-primary-lighter: #cc6b49;
   --ifm-color-primary-lightest: #d48266;
+
+  --ifm-menu-color: #333;
 }
 
 /*
@@ -59,6 +62,8 @@ html[data-theme='dark'] {
   --ifm-color-primary-light: #dc9982;
   --ifm-color-primary-lighter: #dfa38e;
   --ifm-color-primary-lightest: #eac2b4;
+
+  --ifm-menu-color: #e0e0e0;
 }
 
 /*
@@ -88,9 +93,10 @@ html[data-theme='dark'] button.DocSearch-Button {
  * Rush Stack Customization - Sidebars
  */
 ul.theme-doc-sidebar-menu {
-  font-size: 0.8em;
+  font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
 }
-li.theme-doc-sidebar-item-category {
+li.theme-doc-sidebar-item-category.theme-doc-sidebar-item-category-level-1 {
   margin-top: 0.7rem;
 }
 li.theme-doc-sidebar-item-category > a {
@@ -101,6 +107,7 @@ li.theme-doc-sidebar-item-category > a {
  * Rush Stack Customization - Main article
  */
 main {
+  font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 0.9em;
 }
 

--- a/websites/rushstack.io/src/css/custom.css
+++ b/websites/rushstack.io/src/css/custom.css
@@ -122,3 +122,26 @@ main {
   text-align: center;
   padding: 16px;
 }
+
+/*
+ * Rush Stack - Multi-purpose Blockquote
+ */
+blockquote {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  border-color: #c95228;
+  border-style: solid;
+  border-top-width: 1px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 6pt;
+  border-radius: 4pt;
+  background-color: rgb(248, 248, 248);
+}
+html[data-theme='dark'] blockquote {
+  background-color: rgb(32, 32, 32);
+}

--- a/websites/rushstack.io/src/pages/index.md
+++ b/websites/rushstack.io/src/pages/index.md
@@ -1,3 +1,3 @@
 import { Redirect } from '@docusaurus/router';
 
-<Redirect to="/pages/index" />
+<Redirect to="pages/index" />


### PR DESCRIPTION
### SUMMARY

A batch of fixes I'd noted from past PRs:

 - Fix the "highlighting" in the navbar.  (Docusaurus default if not overriden is that a navbar item linking to a page is highlighted if you are on a page that shares a sidebar with that page.  That default works for Docs and API links, but not for some of the other pages because they are accessible from both the Docs sidebar and the top navbar.  We can use the provided `activeBasePage` / `activeBaseRegex` properties to customize this behavior.)
 - Fix the navbar color in dark mode.
 - Customize blockquote style to look more like original site.
 - Customize the Search box in top navbar to be less rounded, adjust colors due to top navbar background color.
 - Bring over font choices from original site.

We also discussed using Docusaurus admonitions instead of blockquotes.  For now, I've decided to just style the blockquote tag and let both the Docs and API Reference sections continue to use blockquotes.  Post-deployment, we can make an effort to begin using (and maybe restyle) admonitions if that makes sense.