### PR TITLE
Fix an error when viewing an event detail page after sign-in

### DIFF
--- a/websites/rushstack.io/src/rscommunity/api/AppSession.ts
+++ b/websites/rushstack.io/src/rscommunity/api/AppSession.ts
@@ -21,7 +21,7 @@ export class AppSession {
 
   public onNavigateToSignIn = (): void => {
     // After logging in, return to the current page
-    Cookies.set('rscommunity-login-return-path', document.location.pathname, {
+    Cookies.set('rscommunity-login-return-url', document.location.href, {
       sameSite: 'Strict',
       domain: document.location.hostname,
       path: '/'
@@ -32,7 +32,9 @@ export class AppSession {
 
   public onNavigateToSignOut = (): void => {
     // The "Sign Out" command should return us to the site homepage
-    Cookies.set('rscommunity-login-return-path', '/', {
+    const siteRootUrl: string = new URL('/', document.location.href).href;
+
+    Cookies.set('rscommunity-login-return-url', siteRootUrl, {
       sameSite: 'Strict',
       domain: document.location.hostname,
       path: '/'


### PR DESCRIPTION
This fixes a bug where the Login-with-GitHub workflow would discard query parameters when returning to a URL like `/community/event?id=1234`.  It relies on a corresponding backend service change that replaces `rscommunity-login-return-path` with `rscommunity-login-return-url` storing the full URL.  (The service validates the URL against the allowed CORS list.)

CC @elliot-nelson @iclanton 