### PR TITLE
Initial Azure DevOps pipelines

### DIFF
--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -1,0 +1,12 @@
+pool:
+  vmImage: 'ubuntu-latest'
+variables:
+  FORCE_COLOR: 1
+jobs:
+  - job: PRBuild
+    displayName: PR Build
+    variables:
+      NodeVersion: 14
+    steps:
+      - checkout: self
+      - template: templates/build.yaml

--- a/common/config/azure-pipelines/deploy.yaml
+++ b/common/config/azure-pipelines/deploy.yaml
@@ -1,0 +1,20 @@
+pr: none
+trigger: main
+pool:
+  vmImage: 'ubuntu-latest'
+variables:
+  FORCE_COLOR: 1
+jobs:
+  - job: Deploy
+    displayName: Deploy
+    variables:
+      NodeVersion: 14
+    steps:
+      - checkout: self
+      - template: templates/build.yaml
+      - script: 'GITHUB_USER=[user] rushx deploy'
+        displayName: Deploy rushjs.io
+        workingDirectory: websites/rushjs.io
+      - script: 'GITHUB_USER=[user] rushx deploy'
+        displayName: Deploy rushstack.io
+        workingDirectory: websites/rushstack.io

--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -1,0 +1,20 @@
+steps:
+  - task: NodeTool@0
+    displayName: 'Use Node $(NodeVersion).x'
+    inputs:
+      versionSpec: '$(NodeVersion).x'
+      checkLatest: true
+  - script: 'git config --local user.email rushbot@users.noreply.github.com'
+    displayName: 'git config email'
+  - script: 'git config --local user.name Rushbot'
+    displayName: 'git config name'
+  - script: 'node common/scripts/install-run-rush.js change --verify'
+    displayName: 'Verify Change Logs'
+  - script: 'node common/scripts/install-run-rush.js install'
+    displayName: 'Rush Install'
+  - script: 'node common/scripts/install-run-rush.js build --verbose'
+    displayName: 'Rush Build'
+    env:
+      # Prevent time-based browserslist update warning
+      # See https://github.com/microsoft/rushstack/issues/2981
+      BROWSERSLIST_IGNORE_OLD_DATA: 1


### PR DESCRIPTION
### SUMMARY

Create initial Azure DevOps pipelines.

The `PR Build` pipeline (`ci.yaml`) should be ready to go, and if desired we can set it up in an Azure project and block merges on a green build.

The `Deploy` pipeline (`deploy.yaml`) is an example implementation.  To work properly we'll need to specify the deploying GitHub user and set up an SSH/API token for authorization in the pipeline, and decide whether we want to run on every merge to main (if desired, we could override that in the UI and just let an Azure project admin run it manually).