### PR TITLE
[rushjs.io] Convert landing page to Docusaurus

### DIFF
--- a/tools/linux-vm/typesense-scraper/rushjs.io-config.json
+++ b/tools/linux-vm/typesense-scraper/rushjs.io-config.json
@@ -1,5 +1,5 @@
 {
-  "index_name": "rushstack.io",
+  "index_name": "rushjs.io",
   "start_urls": ["https://rushjs.io/"],
   "sitemap_urls": ["https://rushjs.io/sitemap.xml"],
   "sitemap_alternate_links": true,

--- a/websites/rushjs.io/docs/pages/advanced/phantom_deps.md
+++ b/websites/rushjs.io/docs/pages/advanced/phantom_deps.md
@@ -20,7 +20,7 @@ a "**diamond dependency**" between these four packages. Conventionally the progr
 For historical reasons, NodeJS and NPM took a different approach by representing this graph physically on disk:
 NPM models the graph vertexes using actual package folder copies, and the graph edges are implied by the
 subfolder relationships. But a folder tree's branches cannot rejoin to make diamonds.
-To handle this, NodeJS added a [special resolution rule](https://nodejs.org/api/modules.html#modules_all_together)
+To handle this, NodeJS added a [special resolution rule](https://nodejs.org/api/modules.html#all-together)
 whose effect is to introduce extra graph edges (pointing to the immediate children of all parent folders).
 From a computer science perspective, this rule relaxes the file system's
 [tree data structure](<https://en.wikipedia.org/wiki/Tree_(data_structure)>) in two ways:

--- a/websites/rushjs.io/docs/pages/advanced/watch_mode.md
+++ b/websites/rushjs.io/docs/pages/advanced/watch_mode.md
@@ -3,7 +3,7 @@
 title: Using watch mode
 ---
 
-Popular tools like [Webpack](https://webpack.js.org/configuration/watch/) and [Jest](https://jestjs.io/en/cli.html)
+Popular tools like [Webpack](https://webpack.js.org/configuration/watch/) and [Jest](https://jestjs.io/docs/cli)
 provide a "watch mode" feature: After the task is completed, the tool enters a loop where it watches the file system
 for changes to your source files. Whenever a change is detected, the task runs again to update its output.
 This speeds up development because (1) rebuilding happens automatically whenever you save a file, and (2) the task

--- a/websites/rushjs.io/docs/pages/contributing.md
+++ b/websites/rushjs.io/docs/pages/contributing.md
@@ -16,7 +16,6 @@ The relevant monorepo project folders are:
 
 - [apps/rush](https://github.com/microsoft/rushstack/tree/master/apps/rush) - the command line interface front end
 - [apps/rush-lib](https://github.com/microsoft/rushstack/tree/master/apps/rush-lib) - the automation API and "engine" where all the logic is implemented
-- [apps/rush-buildxl](https://github.com/microsoft/rushstack/tree/master/apps/rush-buildxl) - adapter for integrating with the [BuildXL](https://github.com/Microsoft/BuildXL) distributed build system
 
 ## Testing Rush builds
 

--- a/websites/rushjs.io/docs/pages/developer/new_developer.md
+++ b/websites/rushjs.io/docs/pages/developer/new_developer.md
@@ -20,7 +20,7 @@ To see Rush's command line help, you can type:
 $ rush -h
 ```
 
-The command-line help is also published online in the [Command Reference](../../commands/rush_change).
+The command-line help is also published online in the [Command Reference](../../commands/rush_add).
 
 ## A couple caveats
 

--- a/websites/rushjs.io/docs/pages/help/faq.md
+++ b/websites/rushjs.io/docs/pages/help/faq.md
@@ -86,7 +86,7 @@ code comments. Recently JSON has gained popularity as a human-edited config file
 comments. As such, most serious JSON libraries can handle comments without any trouble. (A notable exception
 is `JSON.parse()`; don't use that -- it cannot validate schemas and has poor error reporting.)
 
-VS Code highlights JSON comments as errors by default, but it provides an optional "[JSON with comments](https://code.visualstudio.com/languages/identifiers)" mode. To enable this, add this line to
+VS Code highlights JSON comments as errors by default, but it provides an optional "[JSON with comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments)" mode. To enable this, add this line to
 your **settings.json** in VS Code:
 
 ```json
@@ -108,6 +108,6 @@ _For a discussion of some other possibilities, see
 
 Generally it's recommended to perform all monorepo management using Rush. The symlinks that Rush creates under the project `node_modules` folders may confuse other tools such as NPM or Yarn, causing them to malfunction because they expect a different installation model. Sometimes this is unavoidable, however. For example, when migrating an existing repo to use Rush however, the CI system may need to reuse an existing working folder to build different branches that use different installation models. To prevent interference, your CI job will first need to invoke a command that deletes the old files from the previous installation model.
 
-For Yarn or NPM, a command like `git clean -dfx` is generally sufficient. (THIS DELETES FILES -- [read the manual](https://git-scm.com/git-clean) before invoking!)
+For Yarn or NPM, a command like `git clean -dfx` is generally sufficient. (THIS DELETES FILES -- [read the manual](https://git-scm.com/docs/git-clean) before invoking!)
 
 For cleaning up a Rush installation, `git clean` is NOT recommended because it does not handle symlinks reliably. Instead, use the [rush purge](../../commands/rush_purge) command to delete the `node_modules` folders created by Rush.

--- a/websites/rushjs.io/docs/pages/intro/get_started.md
+++ b/websites/rushjs.io/docs/pages/intro/get_started.md
@@ -4,7 +4,7 @@ title: Getting started
 
 ## 3 minute demo
 
-Want to see Rush in action? The only prerequisite you need is [NodeJS](https://github.com/nodejs/node).
+Want to see Rush in action? The only prerequisite you need is [NodeJS](https://nodejs.org/en/download/).
 
 **From your shell, install Rush like this:**
 

--- a/websites/rushjs.io/docs/pages/intro/why_mono.md
+++ b/websites/rushjs.io/docs/pages/intro/why_mono.md
@@ -24,7 +24,10 @@ The **"one repo per package"** model makes sense for isolated projects that are 
 
 The emergent principle becomes **"one Git repo per team"**, or even better **"as few Git repos as possible to get the job done"**.
 
-![My helpful screenshot]({{ "/images/home/mono-concept-h.svg" | absolute_url }}){:style={{ width: "50rem" }}}
+<div>
+  <img src="/images/home/mono-concept-h.svg" alt="monorepo block diagram" style={{ width: '50rem' }} />
+  <p />
+</div>
 
 [Lots](https://danluu.com/monorepo/) [of](https://medium.com/@bebraw/the-case-for-monorepos-907c1361708a) [people](http://blog.shippable.com/our-journey-to-microservices-and-a-mono-repository) who build large scale business software seem to end up with all their code in one big "monorepo". JavaScript is just the last guy to join the party.
 

--- a/websites/rushjs.io/docs/pages/maintainer/add_to_repo.md
+++ b/websites/rushjs.io/docs/pages/maintainer/add_to_repo.md
@@ -124,7 +124,7 @@ There are a few things to keep in mind when creating a `"build"` script:
 
 - If the process returns a non-zero exit status, Rush will assume there was a failure and will block downstream builds.
 
-- If the command writes anything to the `stderr` stream, Rush will interpret this to mean that at least one error or warning was reported. This will break the build. (This is by design -- if you allow people to merge PRs that "cry wolf", pretty soon you will find that so many warnings have accumulated that nobody even reads them any more.) Some tooling libraries (e.g. Jest) write to `stderr` as part of their normal operation; you will need to [redirect their output](https://github.com/microsoft/rushstack/blob/master/core-build/gulp-core-build/src/tasks/JestReporter.ts).
+- If the command writes anything to the `stderr` stream, Rush will interpret this to mean that at least one error or warning was reported. This will break the build. (This is by design -- if you allow people to merge PRs that "cry wolf", pretty soon you will find that so many warnings have accumulated that nobody even reads them any more.) Some tooling libraries (e.g. Jest) write to `stderr` as part of their normal operation; you will need to [redirect their output](https://github.com/microsoft/rushstack-legacy/blob/main/core-build/gulp-core-build/src/tasks/JestReporter.ts#L14).
 
 - If certain projects don't need to be processed by `rush build`, you still need a `build` entry. Set the value to an empty string (`""`) and Rush will ignore it.
 

--- a/websites/rushjs.io/docs/pages/maintainer/build_cache.md
+++ b/websites/rushjs.io/docs/pages/maintainer/build_cache.md
@@ -154,10 +154,10 @@ Currently the `cacheProvider` setting provides three choices:
 - `"azure-blob-storage"`: Microsoft Azure [blob storage container](https://docs.microsoft.com/en-us/azure/storage/blobs/)
 - `"amazon-s3"`: Amazon [S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html)
 
-Other options may be implemented in the future. (Consider contributing one by implementing a subclass of
-[CloudBuildCacheProviderBase](https://github.com/microsoft/rushstack/blob/master/apps/rush-lib/src/logic/buildCache/CloudBuildCacheProviderBase.ts).)
+(The above providers are [modeled as Rush plugins](https://github.com/microsoft/rushstack/tree/master/rush-plugins).
+Custom build cache storage providers can be implemented in the same way.)
 
-For example, here's how we would configure an Azure blob container:
+As one example, here's how to configure an Azure blob container:
 
 **common/config/rush/build-cache.json**
 

--- a/websites/rushjs.io/docs/pages/maintainer/enabling_prettier.md
+++ b/websites/rushjs.io/docs/pages/maintainer/enabling_prettier.md
@@ -29,7 +29,7 @@ which formats files automatically whenever you save.
 
 Before we get to the Git hook, first we need to configure Prettier, and get your existing files prettified.
 
-1.  Since Prettier will run for all files, its [config file](https://prettier.io/en/configuration.html) goes
+1.  Since Prettier will run for all files, its [config file](https://prettier.io/docs/en/configuration.html) goes
     at the root of the repo. Prettier allows many different names for this config file, but despite all that
     flexibility its JSON parser rejects code comments. Therefore it's recommended to use the `.js` file extension.
 

--- a/websites/rushjs.io/docs/pages/maintainer/package_managers.md
+++ b/websites/rushjs.io/docs/pages/maintainer/package_managers.md
@@ -38,8 +38,6 @@ The answer depends on your needs. The Rush developers don't endorse a particular
 
 - Yarn installs faster than NPM (although somewhat slower than PNPM).
 
-- Yarn's "resolutions" feature is not yet compatible with Rush. (See [Rush issue #831](https://github.com/microsoft/rushstack/issues/831).)
-
 - Yarn's "workspaces" are not used in a Rush repo, since they rely on an installation model that doesn't protect against phantom dependencies. Rush's linking strategy is mostly equivalent to workspaces, however.
 
 ## Specifying your package manager

--- a/websites/rushjs.io/docs/pages/maintainer/publishing.md
+++ b/websites/rushjs.io/docs/pages/maintainer/publishing.md
@@ -74,7 +74,7 @@ Version policy is a new concept introduced into Rush to solve the problem of how
 
 ### What is a version policy?
 
-A version policy is set of rules that define how the version should be increased. It is defined in common/config/rush/version-policies.json. An example can be found in [here](https://github.com/microsoft/rushstack/blob/master/common/config/rush/version-policies.json). A public package specifies what version policy it is associated with by providing versionPolicyName in rush.json. An example can be found in [Rush and Rush-lib configuration](https://github.com/microsoft/rushstack/blob/master/rush.json#L46). Multiple packages can use one version policy if they all follow the same rules. When a package is associated with a version policy, it becomes public and can be published when ‘rush publish’ runs.
+A version policy is set of rules that define how the version should be increased. It is defined in common/config/rush/version-policies.json. An example can be found in [here](https://github.com/microsoft/rushstack/blob/master/common/config/rush/version-policies.json). A public package specifies what version policy it is associated with by providing versionPolicyName in rush.json. An example can be found in the [project configuration for rush and rush-lib](https://github.com/microsoft/rushstack/blob/7d05f64c3275da074825bb98d3e49ea920fcfa8f/rush.json#L482). Multiple packages can use one version policy if they all follow the same rules. When a package is associated with a version policy, it becomes public and can be published when ‘rush publish’ runs.
 
 The schema of version-policies.json is defined [here](https://github.com/microsoft/rushstack/blob/master/apps/rush-lib/src/schemas/version-policies.schema.json).
 

--- a/websites/rushjs.io/docusaurus.config.js
+++ b/websites/rushjs.io/docusaurus.config.js
@@ -33,6 +33,13 @@ const config = {
   // Deployment settings above can be overriden based on the TARGET determined at runtime
   ...siteConfig.configOverrides,
 
+  stylesheets: [
+    {
+      href: 'https://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic',
+      type: 'text/css'
+    }
+  ],
+
   themes: ['docusaurus-theme-search-typesense'],
 
   presets: [

--- a/websites/rushjs.io/src/css/custom.css
+++ b/websites/rushjs.io/src/css/custom.css
@@ -5,16 +5,6 @@
  */
 
 /* You can override the default Infima variables here. */
-:root {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: rgb(33, 175, 144);
-  --ifm-color-primary-darker: rgb(31, 165, 136);
-  --ifm-color-primary-darkest: rgb(26, 136, 112);
-  --ifm-color-primary-light: rgb(70, 203, 174);
-  --ifm-color-primary-lighter: rgb(102, 212, 189);
-  --ifm-color-primary-lightest: rgb(146, 224, 208);
-  --ifm-code-font-size: 95%;
-}
 
 .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.1);
@@ -50,6 +40,14 @@ select {
   --ifm-color-primary-light: #c96440;
   --ifm-color-primary-lighter: #cc6b49;
   --ifm-color-primary-lightest: #d48266;
+
+  --ifm-color-secondary: #868e96;
+  --ifm-color-secondary-dark: #778089;
+  --ifm-color-secondary-darker: #707981;
+  --ifm-color-secondary-darkest: #5c636a;
+  --ifm-color-secondary-light: #959ca3;
+  --ifm-color-secondary-lighter: #9da3aa;
+  --ifm-color-secondary-lightest: #b4b9be;
 
   --ifm-menu-color: #333;
 }
@@ -113,7 +111,8 @@ li.theme-doc-sidebar-item-category > a {
  */
 main {
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 0.9em;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 /*

--- a/websites/rushjs.io/src/css/custom.css
+++ b/websites/rushjs.io/src/css/custom.css
@@ -26,7 +26,7 @@ select {
   /*
    * Rush Stack Customization - Infima style overrides
    */
-  --ifm-navbar-height: 4rem;
+  --ifm-navbar-height: 100px;
   --ifm-heading-font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
   /*
@@ -50,6 +50,10 @@ select {
   --ifm-color-secondary-lightest: #b4b9be;
 
   --ifm-menu-color: #333;
+}
+
+.navbar__logo {
+  height: 40px;
 }
 
 /*

--- a/websites/rushjs.io/src/globals.d.ts
+++ b/websites/rushjs.io/src/globals.d.ts
@@ -1,3 +1,4 @@
 declare module '*.module.css';
 declare module '@theme/Layout';
 declare module '@docusaurus/BrowserOnly';
+declare module '@docusaurus/Link';

--- a/websites/rushjs.io/src/index.md
+++ b/websites/rushjs.io/src/index.md
@@ -1,3 +1,0 @@
-### dorks
-
-dork!

--- a/websites/rushjs.io/src/pages/index.module.css
+++ b/websites/rushjs.io/src/pages/index.module.css
@@ -1,0 +1,18 @@
+.masthead {
+  position: relative;
+  background-color: #343a40;
+  color: #ffffff;
+  padding-top: 8rem;
+  padding-bottom: 4rem;
+  margin-bottom: 4rem;
+
+  background: url('/images/bg-masthead-code.jpg') no-repeat center center;
+  background-size: cover;
+}
+
+.mastheadButton {
+  width: 10em;
+  font-size: 1.25rem;
+  color: #ffffff !important;
+  font-weight: 400;
+}

--- a/websites/rushjs.io/src/pages/index.module.css
+++ b/websites/rushjs.io/src/pages/index.module.css
@@ -16,3 +16,86 @@
   color: #ffffff !important;
   font-weight: 400;
 }
+
+.showWhenNarrow {
+  display: block;
+}
+
+@media (min-width: 768px) {
+  .showWhenNarrow {
+    display: none !important;
+  }
+}
+
+.hideWhenNarrow {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .hideWhenNarrow {
+    display: block !important;
+  }
+}
+
+.cardContainerRight,
+.cardContainerLeft {
+  border: 1px solid rgba(0, 0, 0, 0.125);
+  border-radius: 0.25rem;
+  display: flex;
+  margin-bottom: 2rem;
+}
+
+.cardImageBox {
+  display: flex;
+  background-color: #f0f0f0;
+  padding: 1rem;
+}
+
+.cardContentBox {
+  margin-bottom: 1rem;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  margin-top: 4rem;
+}
+
+@media (max-width: 768px) {
+  .cardContainerLeft,
+  .cardContainerRight {
+    flex-direction: column;
+  }
+
+  .cardImageBox {
+    height: 14rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .cardContainerLeft {
+    flex-direction: row;
+  }
+  .cardContainerRight {
+    flex-direction: row-reverse;
+  }
+
+  .cardImageBox {
+    flex-basis: 15rem;
+    flex-grow: 0;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+.advocateCard {
+  margin: 2rem;
+
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  max-width: 8rem;
+
+  text-align: center;
+
+  flex-basis: 200px;
+  flex-grow: 0;
+  flex-shrink: 0;
+}

--- a/websites/rushjs.io/src/pages/index.tsx
+++ b/websites/rushjs.io/src/pages/index.tsx
@@ -1,8 +1,43 @@
 import React from 'react';
 import Layout from '@theme/Layout';
 
+import styles from './index.module.css';
+
 function CustomPage(props: {}): JSX.Element {
-  return <Layout>THIS IS A TEST</Layout>;
+  return (
+    <Layout>
+      <header className={styles.masthead}>
+        <div className="container">
+          <div className="row">
+            <div className="col">
+              <h2 style={{ textAlign: 'center', fontSize: '2rem', fontWeight: 700 }}>
+                Rush: a scalable monorepo manager for the web
+              </h2>
+            </div>
+          </div>
+          <div className="row" style={{ paddingTop: '2rem' }}>
+            <div style={{ marginLeft: 'auto', marginRight: '1rem' }}>
+              <a
+                href="/pages/intro/welcome"
+                className={['button', 'button--secondary', styles.mastheadButton].join(' ')}
+              >
+                Learn More
+              </a>
+            </div>
+            <div style={{ marginRight: 'auto', marginLeft: '1rem' }}>
+              <a
+                href="/pages/intro/get_started"
+                className={['button', 'button--primary', styles.mastheadButton].join(' ')}
+              >
+                Get Started!
+              </a>
+            </div>
+          </div>
+        </div>
+      </header>
+      <div>(content goes here)</div>
+    </Layout>
+  );
 }
 
 export default CustomPage;

--- a/websites/rushjs.io/src/pages/index.tsx
+++ b/websites/rushjs.io/src/pages/index.tsx
@@ -1,9 +1,51 @@
 import React from 'react';
 import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
 
 import styles from './index.module.css';
 
+interface IAdvocate {
+  image: string;
+  title: string;
+  url?: string;
+}
+
+const advocates: IAdvocate[] = [
+  { image: 'onedrive.png', title: 'OneDrive' },
+  { image: 'sharepoint.png', title: 'SharePoint' },
+  { image: 'o365.png', title: 'Office 365 Small Business' },
+  { image: 'windows_store.png', title: 'Windows Store' },
+  { image: 'o365.png', title: 'Office Web Apps' },
+  { image: 'simplrjs.png', title: 'SimplrJS react-forms', url: 'https://github.com/SimplrJS/react-forms' },
+  { image: 'telia.png', title: 'Telia Company', url: 'https://www.telia.se/' },
+  { image: 'wix.png', title: 'Wix', url: 'https://www.wix.com/' }
+];
+
+function AdvocateCard(props: { advocate: IAdvocate }): JSX.Element {
+  const advocate: IAdvocate = props.advocate;
+
+  if (advocate.url) {
+    return (
+      <div className={styles.advocateCard}>
+        <Link to={advocate.url}>
+          <img src={`/images/${advocate.image}`} alt={`${advocate.title} logo`} />
+          <div>{advocate.title}</div>
+        </Link>
+      </div>
+    );
+  } else {
+    return (
+      <div className={styles.advocateCard}>
+        <img src={`/images/${advocate.image}`} alt={`${advocate.title} logo`} />
+        <div>{advocate.title}</div>
+      </div>
+    );
+  }
+}
+
 function CustomPage(props: {}): JSX.Element {
+  let advocateKey: number = 1;
+
   return (
     <Layout>
       <header className={styles.masthead}>
@@ -17,25 +59,170 @@ function CustomPage(props: {}): JSX.Element {
           </div>
           <div className="row" style={{ paddingTop: '2rem' }}>
             <div style={{ marginLeft: 'auto', marginRight: '1rem' }}>
-              <a
-                href="/pages/intro/welcome"
+              <Link
+                to="pages/intro/welcome"
                 className={['button', 'button--secondary', styles.mastheadButton].join(' ')}
               >
                 Learn More
-              </a>
+              </Link>
             </div>
             <div style={{ marginRight: 'auto', marginLeft: '1rem' }}>
-              <a
-                href="/pages/intro/get_started"
+              <Link
+                to="pages/intro/get_started"
                 className={['button', 'button--primary', styles.mastheadButton].join(' ')}
               >
                 Get Started!
-              </a>
+              </Link>
             </div>
           </div>
         </div>
       </header>
-      <div>(content goes here)</div>
+
+      <div
+        style={{
+          maxWidth: '50rem',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+          paddingLeft: '15px',
+          paddingRight: '15px'
+        }}
+      >
+        <p style={{ fontSize: '1.25rem', fontWeight: 300 }}>
+          Rush makes life easier for JavaScript developers who build and publish many packages from a common
+          Git repo. If you're looking to break up your giant application into smaller pieces, and you already
+          realized <Link to="pages/intro/why_mono"> why it doesn't work</Link> to put each package in a
+          separate repo... then Rush is for you!
+        </p>
+        <div className={['container', styles.hideWhenNarrow].join(' ')} style={{ textAlign: 'center' }}>
+          <img src="/images/home/mono-concept-h.svg" style={{ paddingRight: '2em' }} alt="monorepo diagram" />
+        </div>
+
+        <div className={['container', styles.showWhenNarrow].join(' ')} style={{ textAlign: 'center' }}>
+          <img src="/images/home/mono-concept-v.svg" width="80%" alt="monorepo diagram" />
+        </div>
+
+        <h1 style={{ paddingTop: '5rem' }}>The Rush difference</h1>
+        <p>
+          These days many different tools can run "npm install" and "npm run build" in 20 different folders.
+          What's so great about <b>Rush</b>?
+        </p>
+
+        <div className={styles.cardContainerLeft}>
+          <div className={styles.cardImageBox}>
+            <img src="/images/home/card-repo.svg" width="100%" height="100%" alt="Git repositories" />
+          </div>
+          <div className={styles.cardContentBox}>
+            <h2>Ready for large repos</h2>
+            <p>
+              At Microsoft, we build monorepos with hundreds of projects. Rush's unique installation strategy
+              produces a single shrinkwrap/lock file for all your projects that installs extremely fast. Rush
+              supports parallel builds, subset builds, and incremental builds. Distributed multi-machine
+              builds are coming soon!
+            </p>
+          </div>
+        </div>
+
+        <div className={styles.cardContainerRight}>
+          <div className={styles.cardImageBox}>
+            <img src="/images/home/card-people.svg" width="100%" height="100%" alt="large team" />
+          </div>
+          <div className={styles.cardContentBox}>
+            <h2>Designed for large teams</h2>
+            <p>
+              Rush provides many mechanisms for onboarding newcomers and coordinating collaboration between
+              teams. Repo policies allow new package dependencies to be reviewed before they are accepted.
+              Rush can enforce consistent dependency versions across your repo. Different subsets of projects
+              can publish separately with lockstep or independent versioning strategies, private releases, and
+              so forth.
+            </p>
+          </div>
+        </div>
+
+        <div className={styles.cardContainerLeft}>
+          <div className={styles.cardImageBox}>
+            <img src="/images/home/card-phantom.svg" width="80%" height="80%" alt="NPM phantom dependency" />
+          </div>
+          <div className={styles.cardContentBox}>
+            <h2>No phantom dependencies!</h2>
+            <p>
+              Tired of broken imports or mismatched versions when someone else installs your package? Rush's
+              isolated symlinking model eliminates these NPM{' '}
+              <Link to="pages/advanced/phantom_deps">phantom dependencies</Link>, ensuring you'll never again
+              accidentally import a library that was missing from package.json.
+            </p>
+            <p>
+              This algorithm is compatible with <b>PNPM</b>, <b>NPM</b>, and <b>Yarn</b> package managers.
+            </p>
+          </div>
+        </div>
+
+        <div className={styles.cardContainerRight}>
+          <div className={styles.cardImageBox}>
+            <img src="/images/home/card-doppel.svg" width="80%" height="80%" alt="NPM doppelganger" />
+          </div>
+          <div className={styles.cardContentBox}>
+            <h2>No NPM doppelgangers!</h2>
+            <p>
+              Rush's installation model now supports the <b>PNPM</b> package manager, which eliminates{' '}
+              <Link to="pages/advanced/npm_doppelgangers">NPM doppelgangers</Link>. You'll never again find 5
+              copies of the same version of the same library in your node_modules folder!
+            </p>
+          </div>
+        </div>
+
+        <div className={styles.cardContainerLeft}>
+          <div className={styles.cardImageBox}>
+            <img src="/images/home/card-trike.svg" width="100%" height="100%" alt="motorbike and tricycle" />
+          </div>
+          <div className={styles.cardContentBox}>
+            <h2>Easy to administer</h2>
+            <p>
+              When you maintain a large repo, you don't want developers opening support tickets that can't be
+              reproduced on any other computer. Rush helps to ensure that installs and builds are completely
+              deterministic. Even the Rush engine version is automatically installed according to your Git
+              branch. If you define custom commands or options, they are strictly validated and documented as
+              part of Rush's command-line help.
+            </p>
+          </div>
+        </div>
+
+        <div className={styles.cardContainerRight}>
+          <div className={styles.cardImageBox}>
+            <img src="/images/home/card-knife.svg" width="100%" height="100%" alt="army knife" />
+          </div>
+          <div className={styles.cardContentBox}>
+            <h2>Turnkey solution</h2>
+            <p>
+              Tired of cobbling together your developer experience from multiple tools that never seem to
+              integrate properly? Rush is a unified orchestrator that can install, link, build, generate
+              change logs, publish, and bump versions.
+            </p>
+          </div>
+        </div>
+
+        <div className={styles.cardContainerLeft}>
+          <div className={styles.cardImageBox}>
+            <img src="/images/home/card-free.svg" width="100%" height="100%" alt="free price tag" />
+          </div>
+          <div className={styles.cardContentBox}>
+            <h2>Open model</h2>
+            <p>
+              The Rush software is free and open source. Community contributions are welcome! We're also
+              open-minded about your toolchain: In a Rush repo, each project folder remains fully
+              self-contained, individually installable, and easy to relocate if needed. Relatively little
+              effort is required to enable/disable Rush for a given set of projects.
+            </p>
+          </div>
+        </div>
+
+        <h1 style={{ paddingTop: '5rem' }}>Who's using Rush?</h1>
+
+        <div className="row" style={{ paddingBottom: '8rem', justifyContent: 'center' }}>
+          {advocates.map((x) => (
+            <AdvocateCard key={`item-${++advocateKey}`} advocate={x} />
+          ))}
+        </div>
+      </div>
     </Layout>
   );
 }

--- a/websites/rushstack.io/docusaurus.config.js
+++ b/websites/rushstack.io/docusaurus.config.js
@@ -35,6 +35,13 @@ const config = {
   // Deployment settings above can be overriden based on the TARGET determined at runtime
   ...siteConfig.configOverrides,
 
+  stylesheets: [
+    {
+      href: 'https://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic',
+      type: 'text/css'
+    }
+  ],
+
   themes: ['docusaurus-theme-search-typesense'],
 
   presets: [

--- a/websites/rushstack.io/src/css/custom.css
+++ b/websites/rushstack.io/src/css/custom.css
@@ -5,16 +5,6 @@
  */
 
 /* You can override the default Infima variables here. */
-:root {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: rgb(33, 175, 144);
-  --ifm-color-primary-darker: rgb(31, 165, 136);
-  --ifm-color-primary-darkest: rgb(26, 136, 112);
-  --ifm-color-primary-light: rgb(70, 203, 174);
-  --ifm-color-primary-lighter: rgb(102, 212, 189);
-  --ifm-color-primary-lightest: rgb(146, 224, 208);
-  --ifm-code-font-size: 95%;
-}
 
 .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.1);
@@ -50,6 +40,14 @@ select {
   --ifm-color-primary-light: #c96440;
   --ifm-color-primary-lighter: #cc6b49;
   --ifm-color-primary-lightest: #d48266;
+
+  --ifm-color-secondary: #868e96;
+  --ifm-color-secondary-dark: #778089;
+  --ifm-color-secondary-darker: #707981;
+  --ifm-color-secondary-darkest: #5c636a;
+  --ifm-color-secondary-light: #959ca3;
+  --ifm-color-secondary-lighter: #9da3aa;
+  --ifm-color-secondary-lightest: #b4b9be;
 
   --ifm-menu-color: #333;
 }
@@ -113,7 +111,8 @@ li.theme-doc-sidebar-item-category > a {
  */
 main {
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 0.9em;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 /*

--- a/websites/rushstack.io/src/css/custom.css
+++ b/websites/rushstack.io/src/css/custom.css
@@ -26,7 +26,7 @@ select {
   /*
    * Rush Stack Customization - Infima style overrides
    */
-  --ifm-navbar-height: 4rem;
+  --ifm-navbar-height: 100px;
   --ifm-heading-font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
   /*
@@ -50,6 +50,10 @@ select {
   --ifm-color-secondary-lightest: #b4b9be;
 
   --ifm-menu-color: #333;
+}
+
+.navbar__logo {
+  height: 40px;
 }
 
 /*


### PR DESCRIPTION
This change fixes up the `rushjs.io` landing page and its custom styles and responsive layout. The Docusaurus version now reproduces the original site sufficiently that we should be ready to deploy it.

**NOTE:** For this PR I did not revise any of the existing documentation content, even though some of it is clearly outdated. I'd like to get Docusaurus launched first, then we'll circle back and do a series of PRs to tune up the content.