### PR TITLE
Enable Crowdin translation service for rushstack.io project

### DIFF
--- a/websites/rushstack.io/crowdin.yml
+++ b/websites/rushstack.io/crowdin.yml
@@ -1,0 +1,10 @@
+project_id: '503718'
+api_token_env: CROWDIN_PERSONAL_TOKEN
+preserve_hierarchy: true
+files:
+  # JSON translation files
+  - source: /i18n/en/**/*
+    translation: /i18n/%two_letters_code%/**/%original_file_name%
+  # Docs Markdown files
+  - source: /docs/**/*
+    translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%

--- a/websites/rushstack.io/docusaurus.config.js
+++ b/websites/rushstack.io/docusaurus.config.js
@@ -19,7 +19,7 @@ const config = {
   baseUrl: '/',
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'zh-cn']
+    locales: ['en', 'es', 'zh']
   },
 
   trailingSlash: true,


### PR DESCRIPTION
This is an experiment to enable the Crowdin translation service.  

Here is a page that was translated using their machine translation (MT) feature:

![image](https://user-images.githubusercontent.com/4673363/157845800-516de22b-5909-4721-b90e-a4f542378d7b.png)

The Crowdin projects are here:

- `rushstack.io`: https://crowdin.com/project/rush-stack
- `rushjs.io`: https://crowdin.com/project/rushjs

## How I built it:

1. Run `npm install --global @crowdin/cli`
2. Set the  `CROWDIN_PERSONAL_TOKEN` environment variable to a Personal Access Token generated using this page: https://crowdin.com/settings#api-key
3. `cd websites/rushstack.io`
4. `crowdin download` -- download the translated files
5. `rushx start --locale zh` launch the localhost dev server in Chinese mode
6. The `shop.md` file had an error because Crowdin's importer/exporter [corrupted the HTML markup](https://docusaurus.io/docs/next/i18n/crowdin#mdx) in that file.  As a temporary hack, I simply deleted the HTML from that file.  We should find a better solution.

After modifying Markdown content locally, you would run `rushx write-translations` and then `crowdin upload` to update the online service.  