### PR TITLE
Fix deployment error

### DIFF
--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -4,9 +4,11 @@ steps:
     inputs:
       versionSpec: '$(NodeVersion).x'
       checkLatest: true
-  - script: 'git config --local user.email rushbot@users.noreply.github.com'
+    # TODO: "--global" is unsafe for multi-agent CI machines.  We're using it here as a temporary workaround
+    # for a limitation of "docusaurus deploy".  Revert this to "--local" as soon as Docusaurus is fixed.
+  - script: 'git config --global user.email rushbot@users.noreply.github.com'
     displayName: 'git config email'
-  - script: 'git config --local user.name Rushbot'
+  - script: 'git config --global user.name Rushbot'
     displayName: 'git config name'
   - script: 'node common/scripts/install-run-rush.js change --verify'
     displayName: 'Verify Change Logs'


### PR DESCRIPTION
I will create a GitHub issue to get the upstream Docusaurus issue fixed.

## Details

[buildId=8946](https://dev.azure.com/RushStack/GitHubProjects/_build/results?buildId=8946&view=logs&j=e07742bd-189a-5079-918b-43f8b2f94b89&t=22e53604-b2c7-5a3d-c893-a575a94e8040)

Docusaurus does this:
```
Cloning into '/tmp/rushjs.io-website-gh-pagesK8GnMX'...
[INFO] `git clone --depth 1 --branch gh-pages https://rushbot@github.com/microsoft/rushjs.io-website.git "/tmp/rushjs.io-website-gh-pagesK8GnMX"` code: 0
```

But there's no way to locally configure the temporary working folder:
```
[INFO] `git add --all` code: 0
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <vsts@fv-az71-732.54gadnqkfkfezo4rfhga4mummb.dx.internal.cloudapp.net>) not allowed
[INFO] `git commit -m "Deploy website - based on 262529dc8096c52c5da5a7e641bdb0d5787cb70e"` code: 128
```

(Also, why are build outputs being written to `/tmp`??)