### PR TITLE
Fix external link icons

### DIFF
--- a/plugins/theme-rushstack-suite-nav/src/theme/IconExternalLink/index.tsx
+++ b/plugins/theme-rushstack-suite-nav/src/theme/IconExternalLink/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// Docusaurus detects "external links" using an inaccurate test in isInternalUrl() with
+// no way to customize the logic.  Instead of trying to fix that, we hide the "IconExternalLink" component
+// and will instead render our own icon using CSS selectors.
+function IconExternalLink(props: {}): JSX.Element {
+  return <></>;
+}
+
+export default IconExternalLink;

--- a/websites/api.rushstack.io/docusaurus.config.js
+++ b/websites/api.rushstack.io/docusaurus.config.js
@@ -50,6 +50,12 @@ const config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
+
+          // TODO: We should replace API Extractor's breadcrumb links with the native
+          // Docusaurus breadcrumbs.  This work involves updating the API Documenter template
+          // and swizzling @theme/IconHome to remove the house art that clashes with our theme.
+          breadcrumbs: false,
+
           // Please change this to your repo.
           editUrl: 'https://github.com/microsoft/rushstack-websites/tree/main/websites/rushstack.io/',
           remarkPlugins: [

--- a/websites/api.rushstack.io/src/css/custom.css
+++ b/websites/api.rushstack.io/src/css/custom.css
@@ -141,7 +141,7 @@ blockquote {
   padding-right: 1rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
-  border-color: #c95228;
+  border-color: #bc5835;
   border-style: solid;
   border-top-width: 1px;
   border-right-width: 1px;
@@ -152,4 +152,24 @@ blockquote {
 }
 html[data-theme='dark'] blockquote {
   background-color: rgb(37, 32, 31);
+}
+
+/*
+ * Add a little icon next to hyperlinks that point to an external page.
+ * We only do this inside an <article> element.
+ * An "external" page has "://" in its URL and does not include a recognized DNS name.
+ */
+article a[href*="://"]/*
+  */:not([href*="api-extractor.com"])/*
+  */:not([href*="rushstack.io"])/*
+  */:not([href*="rushjs.io"])/*
+  */:not([href*="tsdoc.org"])/*
+  */:not([href*="localhost"]) {
+  background-position: center right;
+  background-repeat: no-repeat;
+  padding-right: 13px;
+
+  /* The hex code for the icon color appears after "fill%3D%22%23" */
+  background-image: linear-gradient(transparent, transparent),
+    url('data:image/svg+xml,%3Csvg width%3D%2211%22 height%3D%2211%22 version%3D%221.1%22 viewBox%3D%220 0 14.364 15.028%22 xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 xmlns%3Acc%3D%22http%3A%2F%2Fcreativecommons.org%2Fns%23%22 xmlns%3Adc%3D%22http%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%22 xmlns%3Ardf%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%22 %3E%3Cmetadata%3E%3Crdf%3ARDF%3E%3Ccc%3AWork%3E%3Cdc%3Acreator%3E%3Ccc%3AAgent%3E%3Cdc%3Atitle%3Ehttps%3A%2F%2Fgithub.com%2Fpgonzal%3C%2Fdc%3Atitle%3E%3C%2Fcc%3AAgent%3E%3C%2Fdc%3Acreator%3E%3C%2Fcc%3AWork%3E%3C%2Frdf%3ARDF%3E%3C%2Fmetadata%3E%3Cg transform%3D%22translate(-82.14 -158.93)%22 fill%3D%22%23bc5835%22 %3E%3Cpath d%3D%22m83.4 161.53c-0.80824-0.0237-1.3558 0.80437-1.2464 1.5543 0.0038 3.237-0.0077 6.4743 0.0058 9.711 0.0539 0.73242 0.77982 1.2548 1.4899 1.151 3.2712-5e-3 6.543 0.01 9.8138-7e-3 0.75077-0.0663 1.2005-0.84784 1.1068-1.5494v-4.0444h-2.1993v3.4019h-8.0176v-8.0176h1.6784v-2.1994h-2.6314z%22%2F%3E%3Cpath d%3D%22m96.504 158.93c-2.5996 0.45395-5.1993 0.90791-7.7989 1.3619 0.56868 0.56868 1.1374 1.1374 1.706 1.706-1.0392 1.0392-2.0785 2.0785-3.1177 3.1177 1.0083 1.0083 2.0166 2.0166 3.025 3.025 1.0392-1.0392 2.0785-2.0785 3.1177-3.1177 0.56868 0.56868 1.1374 1.1374 1.706 1.706 0.45396-2.5996 0.90792-5.1993 1.3619-7.7989z%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E');
 }

--- a/websites/api.rushstack.io/src/css/custom.css
+++ b/websites/api.rushstack.io/src/css/custom.css
@@ -159,12 +159,8 @@ html[data-theme='dark'] blockquote {
  * We only do this inside an <article> element.
  * An "external" page has "://" in its URL and does not include a recognized DNS name.
  */
-article a[href*="://"]/*
-  */:not([href*="api-extractor.com"])/*
-  */:not([href*="rushstack.io"])/*
-  */:not([href*="rushjs.io"])/*
-  */:not([href*="tsdoc.org"])/*
-  */:not([href*="localhost"]) {
+article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"])
+{
   background-position: center right;
   background-repeat: no-repeat;
   padding-right: 13px;

--- a/websites/rushjs.io/docusaurus.config.js
+++ b/websites/rushjs.io/docusaurus.config.js
@@ -54,6 +54,7 @@ const config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
+          breadcrumbs: false,
           // Please change this to your repo.
           editUrl: 'https://github.com/microsoft/rushstack-websites/tree/main/websites/rushjs.io/',
           remarkPlugins: [

--- a/websites/rushjs.io/src/css/custom.css
+++ b/websites/rushjs.io/src/css/custom.css
@@ -141,7 +141,7 @@ blockquote {
   padding-right: 1rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
-  border-color: #c95228;
+  border-color: #bc5835;
   border-style: solid;
   border-top-width: 1px;
   border-right-width: 1px;
@@ -152,4 +152,24 @@ blockquote {
 }
 html[data-theme='dark'] blockquote {
   background-color: rgb(37, 32, 31);
+}
+
+/*
+ * Add a little icon next to hyperlinks that point to an external page.
+ * We only do this inside an <article> element.
+ * An "external" page has "://" in its URL and does not include a recognized DNS name.
+ */
+article a[href*="://"]/*
+  */:not([href*="api-extractor.com"])/*
+  */:not([href*="rushstack.io"])/*
+  */:not([href*="rushjs.io"])/*
+  */:not([href*="tsdoc.org"])/*
+  */:not([href*="localhost"]) {
+  background-position: center right;
+  background-repeat: no-repeat;
+  padding-right: 13px;
+
+  /* The hex code for the icon color appears after "fill%3D%22%23" */
+  background-image: linear-gradient(transparent, transparent),
+    url('data:image/svg+xml,%3Csvg width%3D%2211%22 height%3D%2211%22 version%3D%221.1%22 viewBox%3D%220 0 14.364 15.028%22 xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 xmlns%3Acc%3D%22http%3A%2F%2Fcreativecommons.org%2Fns%23%22 xmlns%3Adc%3D%22http%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%22 xmlns%3Ardf%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%22 %3E%3Cmetadata%3E%3Crdf%3ARDF%3E%3Ccc%3AWork%3E%3Cdc%3Acreator%3E%3Ccc%3AAgent%3E%3Cdc%3Atitle%3Ehttps%3A%2F%2Fgithub.com%2Fpgonzal%3C%2Fdc%3Atitle%3E%3C%2Fcc%3AAgent%3E%3C%2Fdc%3Acreator%3E%3C%2Fcc%3AWork%3E%3C%2Frdf%3ARDF%3E%3C%2Fmetadata%3E%3Cg transform%3D%22translate(-82.14 -158.93)%22 fill%3D%22%23bc5835%22 %3E%3Cpath d%3D%22m83.4 161.53c-0.80824-0.0237-1.3558 0.80437-1.2464 1.5543 0.0038 3.237-0.0077 6.4743 0.0058 9.711 0.0539 0.73242 0.77982 1.2548 1.4899 1.151 3.2712-5e-3 6.543 0.01 9.8138-7e-3 0.75077-0.0663 1.2005-0.84784 1.1068-1.5494v-4.0444h-2.1993v3.4019h-8.0176v-8.0176h1.6784v-2.1994h-2.6314z%22%2F%3E%3Cpath d%3D%22m96.504 158.93c-2.5996 0.45395-5.1993 0.90791-7.7989 1.3619 0.56868 0.56868 1.1374 1.1374 1.706 1.706-1.0392 1.0392-2.0785 2.0785-3.1177 3.1177 1.0083 1.0083 2.0166 2.0166 3.025 3.025 1.0392-1.0392 2.0785-2.0785 3.1177-3.1177 0.56868 0.56868 1.1374 1.1374 1.706 1.706 0.45396-2.5996 0.90792-5.1993 1.3619-7.7989z%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E');
 }

--- a/websites/rushjs.io/src/css/custom.css
+++ b/websites/rushjs.io/src/css/custom.css
@@ -159,12 +159,8 @@ html[data-theme='dark'] blockquote {
  * We only do this inside an <article> element.
  * An "external" page has "://" in its URL and does not include a recognized DNS name.
  */
-article a[href*="://"]/*
-  */:not([href*="api-extractor.com"])/*
-  */:not([href*="rushstack.io"])/*
-  */:not([href*="rushjs.io"])/*
-  */:not([href*="tsdoc.org"])/*
-  */:not([href*="localhost"]) {
+article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"])
+{
   background-position: center right;
   background-repeat: no-repeat;
   padding-right: 13px;

--- a/websites/rushstack.io/docusaurus.config.js
+++ b/websites/rushstack.io/docusaurus.config.js
@@ -54,6 +54,7 @@ const config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
+          breadcrumbs: false,
           // Please change this to your repo.
           editUrl: 'https://github.com/microsoft/rushstack-websites/tree/main/websites/rushstack.io/',
           remarkPlugins: [

--- a/websites/rushstack.io/src/css/custom.css
+++ b/websites/rushstack.io/src/css/custom.css
@@ -141,7 +141,7 @@ blockquote {
   padding-right: 1rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
-  border-color: #c95228;
+  border-color: #bc5835;
   border-style: solid;
   border-top-width: 1px;
   border-right-width: 1px;
@@ -152,4 +152,24 @@ blockquote {
 }
 html[data-theme='dark'] blockquote {
   background-color: rgb(37, 32, 31);
+}
+
+/*
+ * Add a little icon next to hyperlinks that point to an external page.
+ * We only do this inside an <article> element.
+ * An "external" page has "://" in its URL and does not include a recognized DNS name.
+ */
+article a[href*="://"]/*
+  */:not([href*="api-extractor.com"])/*
+  */:not([href*="rushstack.io"])/*
+  */:not([href*="rushjs.io"])/*
+  */:not([href*="tsdoc.org"])/*
+  */:not([href*="localhost"]) {
+  background-position: center right;
+  background-repeat: no-repeat;
+  padding-right: 13px;
+
+  /* The hex code for the icon color appears after "fill%3D%22%23" */
+  background-image: linear-gradient(transparent, transparent),
+    url('data:image/svg+xml,%3Csvg width%3D%2211%22 height%3D%2211%22 version%3D%221.1%22 viewBox%3D%220 0 14.364 15.028%22 xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 xmlns%3Acc%3D%22http%3A%2F%2Fcreativecommons.org%2Fns%23%22 xmlns%3Adc%3D%22http%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%22 xmlns%3Ardf%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%22 %3E%3Cmetadata%3E%3Crdf%3ARDF%3E%3Ccc%3AWork%3E%3Cdc%3Acreator%3E%3Ccc%3AAgent%3E%3Cdc%3Atitle%3Ehttps%3A%2F%2Fgithub.com%2Fpgonzal%3C%2Fdc%3Atitle%3E%3C%2Fcc%3AAgent%3E%3C%2Fdc%3Acreator%3E%3C%2Fcc%3AWork%3E%3C%2Frdf%3ARDF%3E%3C%2Fmetadata%3E%3Cg transform%3D%22translate(-82.14 -158.93)%22 fill%3D%22%23bc5835%22 %3E%3Cpath d%3D%22m83.4 161.53c-0.80824-0.0237-1.3558 0.80437-1.2464 1.5543 0.0038 3.237-0.0077 6.4743 0.0058 9.711 0.0539 0.73242 0.77982 1.2548 1.4899 1.151 3.2712-5e-3 6.543 0.01 9.8138-7e-3 0.75077-0.0663 1.2005-0.84784 1.1068-1.5494v-4.0444h-2.1993v3.4019h-8.0176v-8.0176h1.6784v-2.1994h-2.6314z%22%2F%3E%3Cpath d%3D%22m96.504 158.93c-2.5996 0.45395-5.1993 0.90791-7.7989 1.3619 0.56868 0.56868 1.1374 1.1374 1.706 1.706-1.0392 1.0392-2.0785 2.0785-3.1177 3.1177 1.0083 1.0083 2.0166 2.0166 3.025 3.025 1.0392-1.0392 2.0785-2.0785 3.1177-3.1177 0.56868 0.56868 1.1374 1.1374 1.706 1.706 0.45396-2.5996 0.90792-5.1993 1.3619-7.7989z%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E');
 }

--- a/websites/rushstack.io/src/css/custom.css
+++ b/websites/rushstack.io/src/css/custom.css
@@ -159,12 +159,8 @@ html[data-theme='dark'] blockquote {
  * We only do this inside an <article> element.
  * An "external" page has "://" in its URL and does not include a recognized DNS name.
  */
-article a[href*="://"]/*
-  */:not([href*="api-extractor.com"])/*
-  */:not([href*="rushstack.io"])/*
-  */:not([href*="rushjs.io"])/*
-  */:not([href*="tsdoc.org"])/*
-  */:not([href*="localhost"]) {
+article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"])
+{
   background-position: center right;
   background-repeat: no-repeat;
   padding-right: 13px;


### PR DESCRIPTION
Eliminate these annoying link icons caused by Docusaurus incorrect detection of external URLs:

rushstack.io
![image](https://user-images.githubusercontent.com/4673363/167282206-6571e8cf-9539-4bb5-9479-77c449270333.png)

api.rushstack.io
![image](https://user-images.githubusercontent.com/4673363/167282230-aa3322e3-0341-43aa-9471-6ad2a1fdf1e6.png)
