### PR TITLE
Update get_started.md

### DIFF
--- a/websites/rushjs.io/docs/pages/intro/get_started.md
+++ b/websites/rushjs.io/docs/pages/intro/get_started.md
@@ -12,6 +12,12 @@ Want to see Rush in action? The only prerequisite you need is [NodeJS](https://n
 $ npm install -g @microsoft/rush
 ```
 
+or for npm versions >= 8.12
+
+```sh
+$ npm install --location=global @microsoft/rush
+```
+
 (Don't type the **"$"** of course.) :-)
 
 **For command-line help, do this:**


### PR DESCRIPTION
This updates the `get_started` section to include a small blurb about newer version of npm that use `--location=global` as opposed to `install -g`