### PR TITLE
Fix incorrect chinese translate

### DIFF
--- a/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/commands/rush_deploy.md
+++ b/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/commands/rush_deploy.md
@@ -7,7 +7,7 @@ title: rush deploy
                    [-t PATH] [--create-archive ARCHIVE_PATH]
 
 仓库构建完成后，"rush deploy" 可以将 Rush 仓库内的某些项目和依赖部署到指定的目录下，该目录可
-被上传到开发环境中。"rush deploy" 通过 "rush init-deploy" 生成的配置文件来指定该行为。
+被上传到生产服务器上。"rush deploy" 通过 "rush init-deploy" 生成的配置文件来指定该行为。
 
 可选参数：
   -h, --help            展示帮助信息并退出。


### PR DESCRIPTION
In origin word, `开发环境` means `development environment`.
Correct one is `生产服务器` which means `production server`

Origin text is `After building the repo, "rush deploy" can be used to prepare a deployment by
copying a subset of Rush projects and their dependencies to a target folder,
which can then be uploaded to a production server`