### PR TITLE
[rushjs.io] Bring over website PRs from old repo

### DIFF
--- a/websites/rushjs.io/docs/pages/advanced/installation_variants.md
+++ b/websites/rushjs.io/docs/pages/advanced/installation_variants.md
@@ -141,7 +141,7 @@ $ rush rebuild
 ```
 
 ⏵ If you get tired of typing `--variant`, you can also use the
-[RUSH_PREVIEW_VERSION](../../configs/environment_vars)
+[RUSH_VARIANT](../../configs/environment_vars)
 environment variable to specify the variant name.
 
 **5<!-- -->. Restoring the original state.** When you're done testing your variant, you can return to the original

--- a/websites/rushjs.io/docs/pages/configs/pnpmfile_cjs.md
+++ b/websites/rushjs.io/docs/pages/configs/pnpmfile_cjs.md
@@ -1,11 +1,9 @@
 ---
-layout: page
 title: .pnpmfile.cjs
-navigation_source: docs_nav
 ---
 
-This is the template that [rush init]({% link pages/commands/rush_init.md %})
-generates for **pnpmfile.js**:
+This is the template that [rush init](../../commands/rush_init)
+generates for the monorepo **pnpmfile.js** file:
 
 **common/config/rush/.pnpmfile.cjs**
 

--- a/websites/rushjs.io/docs/pages/developer/other_commands.md
+++ b/websites/rushjs.io/docs/pages/developer/other_commands.md
@@ -4,7 +4,7 @@ title: Other helpful commands
 
 ## Installing the latest SemVer-compatible version of everything
 
-Normally `rush update` only makes the minimal incremental changes necessary to satisfy the the project **package.json** files. If you want to update everything to the latest version, you would do this:
+Normally `rush update` only makes the minimal incremental changes necessary to satisfy the project **package.json** files. If you want to update everything to the latest version, you would do this:
 
 ```sh
 # This effectively deletes the old shrinkwrap file and re-solves everything

--- a/websites/rushjs.io/docs/pages/maintainer/build_cache.md
+++ b/websites/rushjs.io/docs/pages/maintainer/build_cache.md
@@ -247,6 +247,9 @@ See [this article](https://docs.microsoft.com/en-us/azure/storage/common/storage
 about SAS tokens. You can obtain a SAS token via the [Settings > Access keys](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal)
 page for your storage account.
 
+For Amazon S3, this will be your AWS Access Key ID and AWS Secret Access Key separated by a colon,
+such as: `<AccessKeyID>:<SecretAccessKey>`.
+
 If your CI system uses a custom build orchestrator with Rush
 (for example [BuildXL](https://github.com/Microsoft/BuildXL)),
 the [rush write-build-cache](../../commands/rush_write-build-cache) command enables you to

--- a/websites/rushjs.io/docs/pages/maintainer/enabling_prettier.md
+++ b/websites/rushjs.io/docs/pages/maintainer/enabling_prettier.md
@@ -229,9 +229,11 @@ For this situation, Rush's "autoinstaller" feature provides a convenient alterna
     node common/scripts/install-run-rush.js prettier || exit $?
     ```
 
-7.  To actually install the hook, run `rush install`.
+7.  Make the file executable: `chmod +x pre-commit`
 
-8.  Before finally merging your PR, you may want to run `prettier . --write` one last time to reformat any files
+8.  To actually install the hook, run `rush install`.
+
+9.  Before finally merging your PR, you may want to run `prettier . --write` one last time to reformat any files
     that may have been modified before we installed the hook.
 
 You're done! Whenever changes are committed to Git, they will now be automatically prettified.

--- a/websites/rushjs.io/docs/pages/maintainer/publishing.md
+++ b/websites/rushjs.io/docs/pages/maintainer/publishing.md
@@ -34,13 +34,19 @@ This command should have its own build definition. So people can just trigger it
 
 ### Dry run mode
 
+`rush publish` has several flavors of dry runs that allow you to execute intermediate steps of the publish process without actually publishing to an npm registry. This can be useful for testing as well as for creating version bumps and changelogs in situations where this is no external package repository in use for publishing.
+
+    rush publish
+
+When run without any parameters, this does the whole process in a read-only mode, which means the changes are not saved to disk, not committed to the source repository, and packages are not really published. It is useful if you want to check if the version increases and change log updates look right for you.
+
     rush publish --apply
 
-It does the whole process in a dry run mode which means the changes are not committed and packages are not really published. It is useful if you want to check if the version increases and change log updates look right for you.
+In this mode the changes are added to the changelog files and the package.json files are updated with new version numbers and written to disk, but nothing is actually committed to the source repository or published. This is useful if you want to review or edit any of these files before committing to the source repository or publishing to the package repository.
 
     rush publish --apply --target-branch targetBranch
 
-The same dry run mode. The only difference between this one and the previous one is that the changes are committed to the provided target branch.
+In this mode, the changes above are actually committed to a new git branch (prefixed with `publish-`) that is based off of `targetBranch`. Running this command with `targetBranch` set to the branch specified in `repository.defaultBranch` will effectively do everything that a "live" publish would do (including commits to git source), short of actually publishing to an npm repository.
 
 ### Publish mode
 
@@ -64,19 +70,19 @@ Instead of publishing, you also have the option to pack the outputs locally into
 
     rush publish --pack --include-all --publish
 
-> Note: the `--publish` flag disables dry mode, which allows writing the file contents to the disk.
+> Note: Any command that uses the `--publish` flag will disable dry mode, which allows writing the file contents to the disk.
 >
 > You can also use this command in combination with `--release-folder` to hint where the files should be outputted.
 
 ## 3. Version Policy
 
-Version policy is a new concept introduced into Rush to solve the problem of how to notify packages to do different types of version increase when the number of packages is large. For example, rush and rush-lib are always published together and use the same version. Those two versions should always be increased together. Another example is that developers can create different branches to service different major versions. People should not be able to modify the major version in that branch. Version policy solves this kind of problems by defining different policies, one enforcing rush and rush-lib always have the same version and the other locking the major version in a branch.
+Version policy is a new concept introduced into Rush to solve the problem of how to notify packages to do different types of version increase when the number of packages is large. For example, `@microsoft/rush` and `@microsoft/rush-lib` are always published together and use the same version. Those two versions should always be increased together. Another example is that developers can create different branches to service different major versions. People should not be able to modify the major version in that branch. Version policy solves this kind of problems by defining different policies, one enforcing that `rush` and `rush-lib` always have the same version and the other locking the major version in a branch.
 
 ### What is a version policy?
 
-A version policy is set of rules that define how the version should be increased. It is defined in common/config/rush/version-policies.json. An example can be found in [here](https://github.com/microsoft/rushstack/blob/main/common/config/rush/version-policies.json). A public package specifies what version policy it is associated with by providing versionPolicyName in rush.json. An example can be found in the [project configuration for rush and rush-lib](https://github.com/microsoft/rushstack/blob/7d05f64c3275da074825bb98d3e49ea920fcfa8f/rush.json#L482). Multiple packages can use one version policy if they all follow the same rules. When a package is associated with a version policy, it becomes public and can be published when ‘rush publish’ runs.
+A version policy is set of rules that define how the version should be increased. It is defined in **common/config/rush/version-policies.json**. An example can be found in [here](https://github.com/microsoft/rushstack/blob/master/common/config/rush/version-policies.json). A public package specifies what version policy it is associated with by providing `versionPolicyName` in **rush.json**. An example can be found in [Rush and Rush-lib configuration](https://github.com/microsoft/rushstack/blob/master/rush.json#L46). Multiple packages can use one version policy if they all follow the same rules. When a package is associated with a version policy, it becomes public and can be published when `rush publish` runs.
 
-The schema of version-policies.json is defined [here](https://github.com/microsoft/rushstack/blob/main/libraries/rush-lib/src/schemas/version-policies.schema.json).
+The schema of **version-policies.json** is defined [here](https://github.com/microsoft/rushstack/blob/main/libraries/rush-lib/src/schemas/version-policies.schema.json).
 
 ### Two types of version policies
 

--- a/websites/rushjs.io/sidebars.js
+++ b/websites/rushjs.io/sidebars.js
@@ -113,16 +113,13 @@ const sidebars = {
         'pages/configs/environment_vars',
         'pages/configs/npmrc',
         'pages/configs/npmrc-publish',
+        'pages/configs/pnpmfile_cjs',
         'pages/configs/artifactory_json',
         'pages/configs/build-cache_json',
         'pages/configs/command-line_json',
         'pages/configs/common-versions_json',
         'pages/configs/deploy_json',
         'pages/configs/experiments_json',
-        /*
-          TODO - 404 on existing site
-          'pages/configs/pnpmfile_js',
-        */
         'pages/configs/rush_json',
         'pages/configs/rush-project_json',
         'pages/configs/version-policies_json'


### PR DESCRIPTION
This is a rollup of website PRs from the retired Jekyll project at https://github.com/microsoft/rushjs.io-website

- https://github.com/microsoft/rushjs.io-website/pull/104
- https://github.com/microsoft/rushjs.io-website/pull/112
- https://github.com/microsoft/rushjs.io-website/pull/113
- https://github.com/microsoft/rushjs.io-website/pull/116
- https://github.com/microsoft/rushjs.io-website/pull/118
- https://github.com/microsoft/rushjs.io-website/pull/121

NOTE: Some of these doc pages are pretty outdated and have obvious flaws, however I'm going to address that separately, as part of an effort to review the entire `rush.js` website content.  This PR is just cherry-picking fixes from the other repo.

CC @elliot-nelson 