### PR TITLE
Remove "$" from shell samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To facilitate testing of multi-site changes, you can opt to build and deploy all
 at once from a fork of `rushstack-websites`. To do so, first make sure you've forked the project
 and cloned your fork locally, and then run:
 
-```console
+```bash
 rush install
 rush build
 GIT_USER=<your-git-username> rush deploy-fork

--- a/tools/api-documenter-docusaurus-plugin/README.md
+++ b/tools/api-documenter-docusaurus-plugin/README.md
@@ -23,7 +23,7 @@ In your `api-documenter.json`, add the plugin:
 
 Generate your documentation into a subfolder named `api`:
 
-```console
+```bash
 api-documenter generate --input-folder ../../common/temp/api --output-folder ./dist/api
 ```
 

--- a/websites/rushjs.io/README.md
+++ b/websites/rushjs.io/README.md
@@ -46,7 +46,10 @@ rushx serve
 To build the production site and then push it to the `gh-pages` branch of the target repo:
 
 ```
-$ GIT_USER=<Your GitHub username> USE_SSH=true rushx deploy
+export GIT_USER=<Your GitHub username>
+
+# If you use SSH instead of HTTPS authentication, specify this also
+export USE_SSH=true rushx deploy
 ```
 
 (Typically, this deployment will happen in a CI/CD pipeline, which will have the credentials

--- a/websites/rushjs.io/docs/pages/advanced/incremental_builds.md
+++ b/websites/rushjs.io/docs/pages/advanced/incremental_builds.md
@@ -23,13 +23,13 @@ but it may eventually replace incremental builds entirely.)
 To see incremental builds in action, simply run the `rush build` command twice:
 
 ```shell
-$ rush install
+rush install
 
 # This might take several minutes...
-$ rush build
+rush build
 
 # ...but the second time it finishes in just a few seconds.
-$ rush build
+rush build
 ```
 
 The native `rush build` is hard-wired to be incremental. (And `rush rebuild` is the non-incremental variant of
@@ -74,7 +74,7 @@ We might invoke:
 
 ```shell
 # This command will rebuild B, C, and D
-$ rush build
+rush build
 ```
 
 But what if you know that your change to `C` won't affect its API contract? For example, maybe you updated the
@@ -88,7 +88,7 @@ We'd invoke it like this:
 
 ```shell
 # This command will rebuild B (but ignore the effects for C and D)
-$ rush build --changed-projects-only
+rush build --changed-projects-only
 ```
 
 The `--changed-projects-only` is "unsafe" because errors might be encountered if the downstream projects actually

--- a/websites/rushjs.io/docs/pages/advanced/incremental_builds.md
+++ b/websites/rushjs.io/docs/pages/advanced/incremental_builds.md
@@ -22,7 +22,7 @@ but it may eventually replace incremental builds entirely.)
 
 To see incremental builds in action, simply run the `rush build` command twice:
 
-```shell
+```bash
 rush install
 
 # This might take several minutes...
@@ -72,7 +72,7 @@ Projects `C` and `D` depend on `B`, so they need to be built as well:
 
 We might invoke:
 
-```shell
+```bash
 # This command will rebuild B, C, and D
 rush build
 ```
@@ -86,7 +86,7 @@ The `--changed-projects-only` flag tells Rush to build only those projects where
 
 We'd invoke it like this:
 
-```shell
+```bash
 # This command will rebuild B (but ignore the effects for C and D)
 rush build --changed-projects-only
 ```

--- a/websites/rushjs.io/docs/pages/advanced/installation_variants.md
+++ b/websites/rushjs.io/docs/pages/advanced/installation_variants.md
@@ -89,7 +89,7 @@ to your variant folder **common/config/rush/variants/old-widget-sdk**. Three con
 
 Be sure to add the copied files to Git:
 
-```shell
+```bash
 git add .
 git commit -m "Creating a new variant"
 ```
@@ -126,7 +126,7 @@ Note that `^2.3.9` satisfies the SemVer range `^2.3.4 || ^3.0.2` that we specifi
 **4<!-- -->. Install your variant and test it.** Let's start by running `rush update` to install the new set of
 dependency versions:
 
-```shell
+```bash
 rush update --full --variant old-widget-sdk
 ```
 
@@ -136,7 +136,7 @@ supports the `--variant` option. Your CI job can use this when it builds with th
 
 Now you can build and test your variant:
 
-```shell
+```bash
 rush rebuild
 ```
 
@@ -148,7 +148,7 @@ environment variable to specify the variant name.
 state by running `rush install` without the `--variant` option. We call this the "**default variant**", because
 it's the same default behavior as a repo that didn't define any variants:
 
-```shell
+```bash
 # Restore the original state by omitting "--variant":
 rush install
 ```

--- a/websites/rushjs.io/docs/pages/advanced/installation_variants.md
+++ b/websites/rushjs.io/docs/pages/advanced/installation_variants.md
@@ -90,8 +90,8 @@ to your variant folder **common/config/rush/variants/old-widget-sdk**. Three con
 Be sure to add the copied files to Git:
 
 ```shell
-$ git add .
-$ git commit -m "Creating a new variant"
+git add .
+git commit -m "Creating a new variant"
 ```
 
 **3<!-- -->. Override the dependency versions for the variant.** For this example, we will downgrade
@@ -127,7 +127,7 @@ Note that `^2.3.9` satisfies the SemVer range `^2.3.4 || ^3.0.2` that we specifi
 dependency versions:
 
 ```shell
-$ rush update --full --variant old-widget-sdk
+rush update --full --variant old-widget-sdk
 ```
 
 This will update the file **common/config/rush/old-widget-sdk/shrinkwrap.yaml**, install those dependencies
@@ -137,7 +137,7 @@ supports the `--variant` option. Your CI job can use this when it builds with th
 Now you can build and test your variant:
 
 ```shell
-$ rush rebuild
+rush rebuild
 ```
 
 ⏵ If you get tired of typing `--variant`, you can also use the
@@ -150,7 +150,7 @@ it's the same default behavior as a repo that didn't define any variants:
 
 ```shell
 # Restore the original state by omitting "--variant":
-$ rush install
+rush install
 ```
 
 > **Tip:** If you forget which variant is active, you can look in the **common/temp/current-variant.json** file.

--- a/websites/rushjs.io/docs/pages/advanced/watch_mode.md
+++ b/websites/rushjs.io/docs/pages/advanced/watch_mode.md
@@ -47,7 +47,7 @@ How to accomplish that with Rush? Suppose our projects `B` and `C` have a simpli
 
 We might try an experiment like invoking `rush build --to-except D` in an endless loop...
 
-```shell
+```bash
 # Build everything that D depends on (but not D itself),
 # and keep doing that in an endless loop:
 while true; do rush build --to-except D; done

--- a/websites/rushjs.io/docs/pages/advanced/watch_mode.md
+++ b/websites/rushjs.io/docs/pages/advanced/watch_mode.md
@@ -50,7 +50,7 @@ We might try an experiment like invoking `rush build --to-except D` in an endles
 ```shell
 # Build everything that D depends on (but not D itself),
 # and keep doing that in an endless loop:
-$ while true; do rush build --to-except D; done
+while true; do rush build --to-except D; done
 ```
 
 ...and then, while that is running, we invoke `heft start` (or `webpack serve`) in the folder for project `D`.

--- a/websites/rushjs.io/docs/pages/configs/environment_vars.md
+++ b/websites/rushjs.io/docs/pages/configs/environment_vars.md
@@ -103,7 +103,7 @@ field from rush.json.
 For example, if you want to try out a different release of Rush before upgrading your repo, you can assign
 the variable like this:
 
-```shell
+```bash
 # This is Bash notation; for Windows shell, change "export" to be "set"
 export RUSH_PREVIEW_VERSION=5.0.0-dev.25
 

--- a/websites/rushjs.io/docs/pages/configs/environment_vars.md
+++ b/websites/rushjs.io/docs/pages/configs/environment_vars.md
@@ -104,8 +104,10 @@ For example, if you want to try out a different release of Rush before upgrading
 the variable like this:
 
 ```shell
-$ set RUSH_PREVIEW_VERSION=5.0.0-dev.25
-$ rush install
+# This is Bash notation; for Windows shell, change "export" to be "set"
+export RUSH_PREVIEW_VERSION=5.0.0-dev.25
+
+rush install
 ```
 
 ## RUSH_TEMP_FOLDER

--- a/websites/rushjs.io/docs/pages/configs/npmrc-publish.md
+++ b/websites/rushjs.io/docs/pages/configs/npmrc-publish.md
@@ -7,7 +7,7 @@ generates for **.npmrc-publish**:
 
 **common/config/rush/.npmrc-publish**
 
-```shell
+```bash
 # This config file is very similar to common/config/rush/.npmrc, except that .npmrc-publish
 # is used by the "rush publish" command, as publishing often involves different credentials
 # and registries than other operations.

--- a/websites/rushjs.io/docs/pages/configs/npmrc.md
+++ b/websites/rushjs.io/docs/pages/configs/npmrc.md
@@ -7,7 +7,7 @@ generates for the monorepo **.npmrc** file:
 
 **common/config/rush/.npmrc**
 
-```shell
+```bash
 # Rush uses this file to configure the NPM package registry during installation.  It is applicable
 # to PNPM, NPM, and Yarn package managers.  It is used by operations such as "rush install",
 # "rush update", and the "install-run.js" scripts.

--- a/websites/rushjs.io/docs/pages/contributing.md
+++ b/websites/rushjs.io/docs/pages/contributing.md
@@ -23,7 +23,7 @@ Once you have coded your fix and built your branch (as described in the general 
 
 Rush features a mechanism called the **version selector**, which reads `rushVersion` from **rush.json** and then automatically installs and invokes that specific version of the engine. Thus if we launch your build of `@microsoft/rush`, it will not actually run your modified code. To bypass the version selector, we need to invoke the `@microsoft/rush-lib` engine directly:
 
-```shell
+```bash
 cd rushstack/libraries/rush-lib
 
 node ./lib/start.js --help
@@ -33,7 +33,7 @@ If you want to make it easy invoke your test build from other locations, we reco
 
 For Bash on Mac OS or Linux:
 
-```shell
+```bash
 # Substitute the full path to your own build of rush-lib:
 alias testrush="node ~/git/rushstack/libraries/rush-lib/lib/start.js"
 ```
@@ -77,7 +77,7 @@ After saving this file, in VS Code click _"View" --> "Run"_ and choose your "Deb
 
 Rush currently builds using the **gulp-core-build** toolchain which by default runs unit tests, which take a long time. You can bypass them by invoking gulp directly.
 
-```shell
+```bash
 # Full incremental build of Rush and its dependencies, including unit tests
 rush build --to rush-lib --verbose
 

--- a/websites/rushjs.io/docs/pages/contributing.md
+++ b/websites/rushjs.io/docs/pages/contributing.md
@@ -24,8 +24,9 @@ Once you have coded your fix and built your branch (as described in the general 
 Rush features a mechanism called the **version selector**, which reads `rushVersion` from **rush.json** and then automatically installs and invokes that specific version of the engine. Thus if we launch your build of `@microsoft/rush`, it will not actually run your modified code. To bypass the version selector, we need to invoke the `@microsoft/rush-lib` engine directly:
 
 ```shell
-$ cd rushstack/libraries/rush-lib
-$ node ./lib/start.js --help
+cd rushstack/libraries/rush-lib
+
+node ./lib/start.js --help
 ```
 
 If you want to make it easy invoke your test build from other locations, we recommend to create a `testrush` command.
@@ -78,10 +79,10 @@ Rush currently builds using the **gulp-core-build** toolchain which by default r
 
 ```shell
 # Full incremental build of Rush and its dependencies, including unit tests
-$ rush build --to rush-lib --verbose
+rush build --to rush-lib --verbose
 
 # Do a quick build of "rush-lib" only without unit tests
-$ npm install -g gulp
-$ cd rushstack/libraries/rush-lib
-$ gulp build
+cd rushstack/libraries/rush-lib
+
+rushx build
 ```

--- a/websites/rushjs.io/docs/pages/developer/everyday_commands.md
+++ b/websites/rushjs.io/docs/pages/developer/everyday_commands.md
@@ -60,7 +60,7 @@ That's it! Those are all the commonly used Rush commands.
 
 Combining everything, a typical daily incantation might look like this:
 
-```sh
+```bash
 # Pull the latest changes from Git
 git pull
 

--- a/websites/rushjs.io/docs/pages/developer/everyday_commands.md
+++ b/websites/rushjs.io/docs/pages/developer/everyday_commands.md
@@ -62,18 +62,18 @@ Combining everything, a typical daily incantation might look like this:
 
 ```sh
 # Pull the latest changes from Git
-$ git pull
+git pull
 
 # Install NPM packages as needed
-$ rush update
+rush update
 
 # Do a clean rebuild of everything
-$ rush rebuild
+rush rebuild
 
 # Work on one project
-$ cd ./my-project
+cd ./my-project
 
 # Let's assume there is a "start" script in the package.json.
 # (To see the available commands, type "rushx" by itself.)
-$ rushx start
+rushx start
 ```

--- a/websites/rushjs.io/docs/pages/developer/modifying_package_json.md
+++ b/websites/rushjs.io/docs/pages/developer/modifying_package_json.md
@@ -4,7 +4,7 @@ title: Modifying package.json
 
 Let's say you need to add a new dependency on a library "**example-lib**". Without Rush, you would do something like this:
 
-```sh
+```bash
 # DON'T DO THIS IN A RUSH REPO:
 ~/my-repo$ cd apps/my-app
 ~/my-repo/apps/my-app$ npm install --save example-lib
@@ -12,7 +12,7 @@ Let's say you need to add a new dependency on a library "**example-lib**". Witho
 
 In a Rush repo, you should instead use the [rush add](../../commands/rush_add) command:
 
-```sh
+```bash
 ~/my-repo$ cd apps/my-app
 
 # Add "example-lib" as a dependency of "my-app", and then automatically run "rush update":
@@ -21,7 +21,7 @@ In a Rush repo, you should instead use the [rush add](../../commands/rush_add) c
 
 The `rush add` command can also be used to update the version of an existing dependency:
 
-```sh
+```bash
 # Update "my-app" to use "example-lib" version "~1.2.3":
 ~/my-repo/apps/my-app$ rush add --package example-lib@1.2.3
 

--- a/websites/rushjs.io/docs/pages/developer/new_developer.md
+++ b/websites/rushjs.io/docs/pages/developer/new_developer.md
@@ -9,7 +9,7 @@ In order to use Rush, you will need the NodeJS engine. We recommend the latest [
 You also need to install the Rush tool itself. It's pretty easy. From your shell or command prompt, type this:
 
 ```sh
-$ npm install -g @microsoft/rush
+npm install -g @microsoft/rush
 ```
 
 _NOTE: If this command fails because your user account does not have permissions to access NPM's global folder, you may need to [fix your NPM configuration](https://docs.npmjs.com/getting-started/fixing-npm-permissions)._
@@ -17,7 +17,7 @@ _NOTE: If this command fails because your user account does not have permissions
 To see Rush's command line help, you can type:
 
 ```sh
-$ rush -h
+rush -h
 ```
 
 The command-line help is also published online in the [Command Reference](../../commands/rush_add).

--- a/websites/rushjs.io/docs/pages/developer/new_developer.md
+++ b/websites/rushjs.io/docs/pages/developer/new_developer.md
@@ -8,7 +8,7 @@ In order to use Rush, you will need the NodeJS engine. We recommend the latest [
 
 You also need to install the Rush tool itself. It's pretty easy. From your shell or command prompt, type this:
 
-```sh
+```bash
 npm install -g @microsoft/rush
 ```
 
@@ -16,7 +16,7 @@ _NOTE: If this command fails because your user account does not have permissions
 
 To see Rush's command line help, you can type:
 
-```sh
+```bash
 rush -h
 ```
 

--- a/websites/rushjs.io/docs/pages/developer/other_commands.md
+++ b/websites/rushjs.io/docs/pages/developer/other_commands.md
@@ -10,7 +10,7 @@ Normally `rush update` only makes the minimal incremental changes necessary to s
 # This effectively deletes the old shrinkwrap file and re-solves everything
 # using the latest compatible versions as specified in package.json files.
 # Note that the package.json files themselves are not modified.
-$ rush update --full
+rush update --full
 ```
 
 For everyday work, `--full` can introduce unrelated breaks in your PR branch, for example if one of the dependencies didn't perfectly follow the SemVer rules. This isn't too much of a concern for small repos. For a large monorepo, we recommended to use `rush update` for everyday work, and then run `rush update --full` periodically as a separate workflow by a CI job or designated person.
@@ -32,15 +32,15 @@ For example:
 ```sh
 # Only install the NPM packages needed to build "my-project" and the other
 # Rush projects that it depends on:
-$ rush install --to my-project
+rush install --to my-project
 
 # Like with "rush build", you can use "." to refer to the project from your
 # shell's current working directory:
-$ cd my-project
-$ rush install --to .
+cd my-project
+rush install --to .
 
 # Here's how to install dependencies required to do "rush build --from my-project"
-$ rush install --from my-project
+rush install --from my-project
 ```
 
 ## Getting back to a clean state
@@ -49,9 +49,9 @@ After working with Rush, maybe you want to get back to a clean state, e.g. so yo
 
 ```sh
 # Remove all the symlinks created by Rush:
-$ rush unlink
+rush unlink
 
 # Remove all the temporary files created by Rush, including deleting all
 # the NPM packages that were installed in your common folder:
-$ rush purge
+rush purge
 ```

--- a/websites/rushjs.io/docs/pages/developer/other_commands.md
+++ b/websites/rushjs.io/docs/pages/developer/other_commands.md
@@ -6,7 +6,7 @@ title: Other helpful commands
 
 Normally `rush update` only makes the minimal incremental changes necessary to satisfy the project **package.json** files. If you want to update everything to the latest version, you would do this:
 
-```sh
+```bash
 # This effectively deletes the old shrinkwrap file and re-solves everything
 # using the latest compatible versions as specified in package.json files.
 # Note that the package.json files themselves are not modified.
@@ -29,7 +29,7 @@ If your repo is using PNPM with the new `useWorkspaces=true` mode enabled in you
 
 For example:
 
-```sh
+```bash
 # Only install the NPM packages needed to build "my-project" and the other
 # Rush projects that it depends on:
 rush install --to my-project
@@ -47,7 +47,7 @@ rush install --from my-project
 
 After working with Rush, maybe you want to get back to a clean state, e.g. so you can zip up a folder. Here's a couple commands to do that:
 
-```sh
+```bash
 # Remove all the symlinks created by Rush:
 rush unlink
 

--- a/websites/rushjs.io/docs/pages/developer/selecting_subsets.md
+++ b/websites/rushjs.io/docs/pages/developer/selecting_subsets.md
@@ -25,9 +25,9 @@ on project `B`. You need to build all the things that `B` depends on, and also `
 
 Here's how to do that:
 
-```shell
+```bash
 # Build everything up to (and including) project B
-$ rush build --to B
+rush build --to B
 ```
 
 The projects selected by this command are `A`, `B`, and `E`:
@@ -40,12 +40,12 @@ The projects selected by this command are `A`, `B`, and `E`:
 will be to invoke Webpack or Jest in "watch mode" for `B`. You can use `--to-except` instead
 of `--to` to exclude `B`.
 
-```shell
+```bash
 # Build everything up to project B, but not B itself
-$ rush build --to-except B
+rush build --to-except B
 
 # Invoke Jest watch mode to build B
-$ heft test --watch
+heft test --watch
 ```
 
 The projects selected by this command are `A` and `E`:
@@ -60,9 +60,9 @@ we also need to include its dependency `G`. The `--from` command does this. It w
 since they're required by `B`. (Since `rush build` is incremental, `A` and `E` will probably get skipped assuming
 they are still up to date.)
 
-```shell
+```bash
 # Build everything downstream from B, including any implied dependencies
-$ rush build --from B
+rush build --from B
 ```
 
 This command selects everything except for `F`:
@@ -84,9 +84,9 @@ not relevant right now.
 In these situations the `--impacted-by` parameter can be handy: It means _"Select only those projects
 that might be broken by a change to B, and trust me that their dependencies are in a usable state."_
 
-```shell
+```bash
 # Build B and everything downstream from B, but don't include dependencies
-$ rush build --impacted-by B
+rush build --impacted-by B
 ```
 
 The projects selected by this command are `B`, `C`, and `D`:
@@ -98,9 +98,9 @@ The projects selected by this command are `B`, `C`, and `D`:
 **Possible scenario:** This is the same as `--impacted-by` except that it does not include `B` itself. For example
 that might make sense if you already built `B` manually while implementing the thing that we now want to test.
 
-```shell
+```bash
 # Build everything downstream from B, but don't include dependencies
-$ rush build --impacted-by-except B
+rush build --impacted-by-except B
 ```
 
 The projects selected by this command are `C` and `D`:
@@ -112,9 +112,9 @@ The projects selected by this command are `C` and `D`:
 **Possible scenario:** As its name implies, the `--only` parameter adds exactly one project to the selection,
 ignoring dependencies.
 
-```shell
+```bash
 # Build only B and nothing else
-$ rush build --only B
+rush build --only B
 ```
 
 <img src="/images/docs/selection-only.svg" alt="rush build --only B" style={{ height: "150px" }} />
@@ -248,8 +248,8 @@ rush list --only tag:frontend-team-libs --detailed
 
 Here's a more complex combined command-line:
 
-```shell
-$ rush build --only A --impacted-by-except B --to F
+```bash
+rush build --only A --impacted-by-except B --to F
 ```
 
 The projects selected by this example are `A`, `C`, `D`, `E`, and `F`:

--- a/websites/rushjs.io/docs/pages/help/faq.md
+++ b/websites/rushjs.io/docs/pages/help/faq.md
@@ -34,13 +34,13 @@ For more details, check out the [Rush Stack](https://rushstack.io/) website.
 This problem isn't specific to Rush, but we hear about it a lot because Rush is one of the first tools people need to invoke when starting work in a repo. The symptoms look like this:
 
 ```
-$ npm install -g @microsoft/rush
+C:\> npm install -g @microsoft/rush
 C:\Program Files\nodejs\rush -> C:\Program Files\nodejs\node_modules\@microsoft\
 rush\bin\rush
 C:\Program Files\nodejs
 `-- @microsoft/rush@3.0.1
 
-$ rush
+C:\> rush
 Rush Multi-Package Build Tool 2.5.0 - http://aka.ms/rush
 ```
 

--- a/websites/rushjs.io/docs/pages/intro/get_started.md
+++ b/websites/rushjs.io/docs/pages/intro/get_started.md
@@ -9,39 +9,37 @@ Want to see Rush in action? The only prerequisite you need is [NodeJS](https://n
 **From your shell, install Rush like this:**
 
 ```sh
-$ npm install -g @microsoft/rush
+npm install -g @microsoft/rush
 ```
-
-(Don't type the **"$"** of course.) :-)
 
 **For command-line help, do this:**
 
 ```sh
-$ rush -h
+rush -h
 ```
 
 **To see Rush build some real projects, try running these commands:**
 
 ```sh
-$ git clone https://github.com/microsoft/rushstack
-$ cd rushstack
+git clone https://github.com/microsoft/rushstack
+cd rushstack
 
 # Install the NPM packages:
 # (If you don't have a GitHub email configured, add the "--bypass-policy" option.)
-$ rush update
+rush update
 
 # Incremental install:
-$ rush update  # <-- instantaneous!
+rush update  # <-- instantaneous!
 
 # Force all projects to be rebuilt:
-$ rush rebuild
+rush rebuild
 
 # Incremental build:
-$ rush build    # <-- instantaneous!
+rush build    # <-- instantaneous!
 
 # Use "--verbose" to view the console logs for each project as it is built.
 # Projects build in parallel processes, but their logs are collated.
-$ rush rebuild --verbose
+rush rebuild --verbose
 ```
 
 ## Let's get started!

--- a/websites/rushjs.io/docs/pages/intro/get_started.md
+++ b/websites/rushjs.io/docs/pages/intro/get_started.md
@@ -8,19 +8,19 @@ Want to see Rush in action? The only prerequisite you need is [NodeJS](https://n
 
 **From your shell, install Rush like this:**
 
-```sh
+```bash
 npm install -g @microsoft/rush
 ```
 
 **For command-line help, do this:**
 
-```sh
+```bash
 rush -h
 ```
 
 **To see Rush build some real projects, try running these commands:**
 
-```sh
+```bash
 git clone https://github.com/microsoft/rushstack
 cd rushstack
 

--- a/websites/rushjs.io/docs/pages/maintainer/add_to_repo.md
+++ b/websites/rushjs.io/docs/pages/maintainer/add_to_repo.md
@@ -131,7 +131,7 @@ There are a few things to keep in mind when creating a `"build"` script:
 Now let's try building your project. From anywhere under the folder containing **rush.json**, run this command (which builds all projects in the repo):
 
 ```
-$ rush build
+rush build
 ```
 
 Rush provides a lot of command-line switches for building projects. See [rush build](../../commands/rush_build) and [rush rebuild](../../commands/rush_rebuild) for details.

--- a/websites/rushjs.io/docs/pages/maintainer/build_cache.md
+++ b/websites/rushjs.io/docs/pages/maintainer/build_cache.md
@@ -102,9 +102,11 @@ to copy this file into each project folder.
 
 Now you should see projects being cached as shown in this sample log output:
 
-```shell
-$ rush rebuild --verbose
+```bash
+rush rebuild --verbose
+```
 
+```
 . . .
 
 ==[ example-project ]==============================================[ 1 of 5 ]==
@@ -124,9 +126,11 @@ Successfully set cache entry.
 
 When we run the same command a second time, Rush extracts the archive instead of invoking the build task:
 
-```shell
-$ rush rebuild --verbose
+```bash
+rush rebuild --verbose
+```
 
+```
 . . .
 
 ==[ example-project ]==============================================[ 1 of 5 ]==
@@ -214,10 +218,11 @@ A more security-conscious organization however will prefer to require authentica
 Rush provides a [rush update-cloud-credentials](../../commands/rush_update-cloud-credentials)
 command to make this easy for users to set up:
 
-```shell
-$ rush update-cloud-credentials --interactive
+```bash
+rush update-cloud-credentials --interactive
+```
 
-
+```
 Rush Multi-Project Build Tool 5.45.6 (unmanaged) - https://rushjs.io
 Node.js version is 12.20.1 (LTS)
 

--- a/websites/rushjs.io/docs/pages/maintainer/deploying.md
+++ b/websites/rushjs.io/docs/pages/maintainer/deploying.md
@@ -31,7 +31,7 @@ by `rush init`. Instead, you create the file using [rush init-deploy](../../comm
 
 Continuing our example, we can create the file using this command:
 
-```shell
+```bash
 # Create common/config/rush/deploy.json and configure it to deploy "app1"
 rush init-deploy --project app1
 ```
@@ -43,7 +43,7 @@ commit this file to Git.
 
 To copy the files to the deployment target folder, you would use these commands:
 
-```shell
+```bash
 # Install dependencies
 rush install
 
@@ -64,7 +64,7 @@ organized similarly to the monorepo's folder structure:
 
 You can test that the deployment worked correctly by executing `app1` from within the deployment target folder:
 
-```shell
+```bash
 # Change to the app1 location under the target folder
 cd common/deploy/apps/app1
 
@@ -113,9 +113,9 @@ If you specify `"linkCreation": "script"` then `rush deploy` will create the **c
 any links. After you have uploaded this folder to your server machine, you can then invoke the script
 to create the links:
 
-```shell
+```bash
 # Invoke this command on the server machine, after the files have been uploaded
-$ node create-links.js create
+node create-links.js create
 ```
 
 > NOTE: When using `"linkCreation": "script"`, the current implementation does not yet generate the
@@ -166,12 +166,12 @@ like this:
 
 When performing the deployment, the `--project` parameter selects which project to deploy. For example:
 
-```shell
+```bash
 # Copy app1 and its dependencies to /mnt/deploy/app1
-$ rush deploy --project app1 --target-folder /mnt/deploy/app1
+rush deploy --project app1 --target-folder /mnt/deploy/app1
 
 # Copy app2 and its dependencies to /mnt/deploy/app2
-$ rush deploy --project app2 --target-folder /mnt/deploy/app2
+rush deploy --project app2 --target-folder /mnt/deploy/app2
 ```
 
 The `--target-folder` parameter copies the files to a custom location instead of the **common/deploy/** default folder.
@@ -187,25 +187,25 @@ We will create two config files:
 
 Both of these files can be created using `rush init-deploy`:
 
-```shell
+```bash
 # Create common/config/rush/deploy.json
-$ rush init-deploy --project app1
+rush init-deploy --project app1
 
 # Create common/config/rush/deploy-app2-example.json
-$ rush init-deploy --project app2 --scenario app2-example
+rush init-deploy --project app2 --scenario app2-example
 ```
 
 After editing **deploy-app2-example.json** to specify `"linkCreation": "script"`, we can now use the
 `--scenario` parameter with `rush deploy`:
 
-```shell
+```bash
 # Copy app1 and its dependencies to /mnt/deploy/app1
 # Uses scenario file: common/config/rush/deploy.json
-$ rush deploy --target-folder /mnt/deploy/app1
+rush deploy --target-folder /mnt/deploy/app1
 
 # Copy app2 and its dependencies to /mnt/deploy/app2
 # Uses scenario file: common/config/rush/deploy-app2-example.json
-$ rush deploy --target-folder /mnt/deploy/app2 --scenario app2-example
+rush deploy --target-folder /mnt/deploy/app2 --scenario app2-example
 ```
 
 Note that the `--project` parameter is not needed with `rush deploy` because each config file has only one project

--- a/websites/rushjs.io/docs/pages/maintainer/deploying.md
+++ b/websites/rushjs.io/docs/pages/maintainer/deploying.md
@@ -33,7 +33,7 @@ Continuing our example, we can create the file using this command:
 
 ```shell
 # Create common/config/rush/deploy.json and configure it to deploy "app1"
-$ rush init-deploy --project app1
+rush init-deploy --project app1
 ```
 
 After the file **deploy.json** is created, open it in your editor and adjust the settings as appropriate. Then
@@ -45,13 +45,13 @@ To copy the files to the deployment target folder, you would use these commands:
 
 ```shell
 # Install dependencies
-$ rush install
+rush install
 
 # Build the monorepo
-$ rush build
+rush build
 
 # Copy app1 and its dependencies to the default target folder: common/deploy/
-$ rush deploy
+rush deploy
 ```
 
 This will prepare a deployment by copying `app1` and its dependencies the target folder. The copied files will be
@@ -66,10 +66,10 @@ You can test that the deployment worked correctly by executing `app1` from withi
 
 ```shell
 # Change to the app1 location under the target folder
-$ cd common/deploy/apps/app1
+cd common/deploy/apps/app1
 
 # Invoke the package.json script that starts the web service
-$ rushx start
+rushx start
 ```
 
 If the project fails to run (but worked correctly from its original location **apps/app1**), then you many

--- a/websites/rushjs.io/docs/pages/maintainer/enabling_ci_builds.md
+++ b/websites/rushjs.io/docs/pages/maintainer/enabling_ci_builds.md
@@ -8,22 +8,22 @@ If we were invoking these commands manually, it might look something like this:
 
 ```sh
 # Fetch the main branch
-$ git fetch origin main:refs/remotes/origin/main -a
+git fetch origin main:refs/remotes/origin/main -a
 
 # (optional) Fail if the developer didn't create a required change log.
 # By "fail", we mean that the script will stop because Rush returned
 # a nonzero exit code.
-$ rush change -v
+rush change -v
 
 # Install NPM packages in the common folder, but don't automatically do "rush link"
-$ rush install --no-link
+rush install --no-link
 
 # Run "rush link" explicitly, so your CI system can measure it as a separate step
-$ rush link
+rush link
 
 # Do a full "ship" build, showing detailed logs in real time
 # (We assume "--ship" was defined in common/config/rush/command-line.json)
-$ rush rebuild --ship --verbose
+rush rebuild --ship --verbose
 ```
 
 But there's one hitch -- what if your CI environment doesn't come with Rush preinstalled?

--- a/websites/rushjs.io/docs/pages/maintainer/enabling_ci_builds.md
+++ b/websites/rushjs.io/docs/pages/maintainer/enabling_ci_builds.md
@@ -6,7 +6,7 @@ When you set up a PR build definition for continuous integration, the automated 
 
 If we were invoking these commands manually, it might look something like this:
 
-```sh
+```bash
 # Fetch the main branch
 git fetch origin main:refs/remotes/origin/main -a
 

--- a/websites/rushjs.io/docs/pages/maintainer/npm_registry_auth.md
+++ b/websites/rushjs.io/docs/pages/maintainer/npm_registry_auth.md
@@ -42,7 +42,7 @@ identified by their `@example` NPM scope.
 
 **common/config/rush/.npmrc**
 
-```shell
+```bash
 # Map your company's NPM scope ("@example") to the private registry URL:
 @example:registry=https://my-registry.example.com/npm-private/
 
@@ -66,7 +66,7 @@ Your setup might look like this:
 
 **common/config/rush/.npmrc**
 
-```shell
+```bash
 # Map everything to the private registry URL
 registry=https://my-registry.example.com/npm-private/
 always-auth=true

--- a/websites/rushjs.io/docs/pages/maintainer/phased_builds.md
+++ b/websites/rushjs.io/docs/pages/maintainer/phased_builds.md
@@ -139,7 +139,7 @@ Here, we've defined one flag (`--production`) that can be specified on all 4 var
 
 So, if we were to execute this command:
 
-```console
+```bash
 rush test --production --update-snapshots
 ```
 

--- a/websites/rushjs.io/docs/pages/maintainer/setup_policies.md
+++ b/websites/rushjs.io/docs/pages/maintainer/setup_policies.md
@@ -55,8 +55,11 @@ Rush can help, though. The "gitPolicy" setting in **rush.json** allows you to sp
 
 Whenever the developer runs `rush install`, Rush will check that their e-mail address follows one of the patterns. If not, it displays a warning like this:
 
+```bash
+rush install
 ```
-$ rush install
+
+```
 Rush Multi-Package Build Tool
 
 Checking Git policy for this repository.

--- a/websites/rushstack.io/docs/pages/heft_tasks/jest.md
+++ b/websites/rushstack.io/docs/pages/heft_tasks/jest.md
@@ -20,7 +20,7 @@ That said, if for some reason you need to run tests in some other runtime such a
 
 Heft has direct dependencies on the Jest packages that it needs, so you don't need to add Jest to your project's **package.json** file. Instead, you will need to install the Heft plugin package:
 
-```shell
+```bash
 $ rush add --package @rushstack/heft-jest-plugin --dev
 ```
 

--- a/websites/rushstack.io/docs/pages/heft_tasks/webpack.md
+++ b/websites/rushstack.io/docs/pages/heft_tasks/webpack.md
@@ -23,7 +23,7 @@ Webpack should be used for projects whose output is a web application bundle. We
 
 Heft has direct dependencies on the Webpack packages that it needs, so you don't normally need to add Webpack to your project's **package.json** file. Instead, you will need to install the Heft plugin package for the version of Webpack that you want to use:
 
-```shell
+```bash
 # (CHOOSE ONE)
 
 # If you want to use Webpack 5
@@ -35,7 +35,7 @@ $ rush add --package @rushstack/heft-webpack4-plugin --dev
 
 You should also add `@types/webpack-env` to your project, which provides TypeScript typings for the Webpack environment:
 
-```shell
+```bash
 $ rush add --package @types/webpack-env --exact  --dev
 ```
 


### PR DESCRIPTION
https://github.com/microsoft/rushstack-websites/issues/42 reported that the `$` character is potentially confusing in example snippets for shell commands.  Let's fix that.