### PR TITLE
phased builds docs fixes

### DIFF
--- a/websites/rushjs.io/docs/pages/maintainer/phased_builds.md
+++ b/websites/rushjs.io/docs/pages/maintainer/phased_builds.md
@@ -100,7 +100,7 @@ In `common/config/rush/command-line.json`, in the `"commands"` section, redefine
       "summary": "Build and test all projects.",
       "phases": ["_phase:build", "_phase:test"],
       "enableParallelism": true,
-      "incremental": true
+      "incremental": false
     }
   ]
 }

--- a/websites/rushjs.io/docs/pages/maintainer/phased_builds.md
+++ b/websites/rushjs.io/docs/pages/maintainer/phased_builds.md
@@ -173,7 +173,7 @@ Some projects may not have any meaningful work to do for a phase, in which case 
 
 ## Define per-phase output folder names
 
-Within the `rush-project.json` configuration file of each project (or, preferably, each rig profile), redefine your `operationSettings` so that each folder is specified in only one phase. For exampe:
+Within the `rush-project.json` configuration file of each project (or, preferably, each rig profile), redefine your `operationSettings` so that each folder is specified in only one phase. For example:
 
 ```json
 {

--- a/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/maintainer/phased_builds.md
+++ b/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/maintainer/phased_builds.md
@@ -100,7 +100,7 @@ In `common/config/rush/command-line.json`, in the `"commands"` section, redefine
       "summary": "Build and test all projects.",
       "phases": ["_phase:build", "_phase:test"],
       "enableParallelism": true,
-      "incremental": true
+      "incremental": false
     }
   ]
 }
@@ -173,7 +173,7 @@ Some projects may not have any meaningful work to do for a phase, in which case 
 
 ## Define per-phase output folder names
 
-Within the `rush-project.json` configuration file of each project (or, preferably, each rig profile), redefine your `operationSettings` so that each folder is specified in only one phase. For exampe:
+Within the `rush-project.json` configuration file of each project (or, preferably, each rig profile), redefine your `operationSettings` so that each folder is specified in only one phase. For example:
 
 ```json
 {


### PR DESCRIPTION
just set up phased builds in our monorepo, a couple of docs fixes from the process

other anecdotes that might be helpful:
- team member that made the change missed the `Old configuration` / `New configuration` comments in [this section](https://github.com/microsoft/rushstack-websites/blob/main/websites/rushjs.io/docs/pages/maintainer/phased_builds.md#define-per-phase-output-folder-names) and pasted the whole block, wondering if we should consider splitting it up into two totally separate code blocks of before and after?
- we also ran into an issue where before we didn't have generated sources in our output folders but got away with it because only the compiled `lib` folder was being used by downstream projects.  now that the test phase depends on our build phase, and jest looks at typescript files for reporting not just compiled js, our setup failed when the build phase was cached and the test phase was not until we added `src/__generated__` to our build phase outputs (jest was looking for and failing to find files in that folder).  maybe just our fault / no easy way to call this out in the docs but would imagine others might have "hidden" outputs that need to now be accounted for