### PR TITLE
Fix typo in `ci.yml` path

### DIFF
--- a/websites/rushjs.io/docs/pages/maintainer/enabling_ci_builds.md
+++ b/websites/rushjs.io/docs/pages/maintainer/enabling_ci_builds.md
@@ -88,7 +88,7 @@ with GitHub and is free for open source projects. The `rush init` command create
 that's a good starting point if you use this service. Note how it uses **install-run-rush.js**
 to invoke the Rush tool:
 
-**.githib/workflows/ci.yml**
+**.github/workflows/ci.yml**
 
 ```yaml
 name: CI


### PR DESCRIPTION
After reading the docs i found a minor typo and fixed it.

