### PR TITLE
Fix typo in sass_json markdown file

### DIFF
--- a/websites/rushstack.io/docs/pages/heft_configs/sass_json.md
+++ b/websites/rushstack.io/docs/pages/heft_configs/sass_json.md
@@ -42,7 +42,7 @@ title: sass.json
   // "fileExtensions": [
   //   ".sass",
   //   ".scss",
-  //   ".css
+  //   ".css"
   // ],
 
   /**


### PR DESCRIPTION
Found a typo in the docs so wanted to help fix it.