### PR TITLE
Document Heft environment variables

### DIFF
--- a/websites/rushstack.io/docs/pages/heft_configs/environment_vars.md
+++ b/websites/rushstack.io/docs/pages/heft_configs/environment_vars.md
@@ -1,0 +1,49 @@
+---
+title: Environment variables
+---
+
+Heft's behavior can be customized using the shell environment variables described below:
+
+## HEFT_JEST_DETECT_OPEN_HANDLES
+
+This environment variable provides an alternate method for specifying the
+`--detect-open-handles` parameter for `@rushstack/heft-jest-plugin`.
+
+## HEFT_JEST_DISABLE_CODE_COVERAGE
+
+This environment variable provides an alternate method for specifying the
+`--disable-code-coverage` parameter for `@rushstack/heft-jest-plugin`.
+
+## HEFT_JEST_MAX_WORKERS
+
+This environment variable provides an alternate method for specifying the
+`--max-workers` parameter for `@rushstack/heft-jest-plugin`.
+
+## HEFT_JEST_TEST_TIMEOUT_MS
+
+This environment variable provides an alternate method for specifying the
+`--test-timeout-ms` parameter for `@rushstack/heft-jest-plugin`.
+
+## RUSHSTACK_FILE_ERROR_BASE_FOLDER
+
+Controls how source file paths are displayed when printing diagnostic messages such as errors or warnings.
+
+Possible values:
+
+- **_(an absolute path)_**: the printed path will be relative to the specified absolute path
+- `{PROJECT_FOLDER}`: a special token indicating that the printed path will be relative to the project folder (that contains **package.json**)
+- `{ABSOLUTE_PATH}`: a special token indicating that the printed path should be an absolute path
+
+The default value is `{PROJECT_FOLDER}`, however when Rush invokes commands such as Heft, it sets `RUSHSTACK_FILE_ERROR_BASE_FOLDER` to be the path of the root folder that contains **rush.json**.
+
+> NOTE: The `RUSHSTACK_FILE_ERROR_BASE_FOLDER` functionality is implemented by the general-purpose [FileError](https://api.rushstack.io/pages/node-core-library.fileerror/) API from `@rushstack/node-core-library`.
+
+## WEBPACK_DEV_SERVER
+
+By default `@rushstack/heft-webpack4-plugin` and `@rushstack/heft-webpack5-plugin` look for an NPM package called `webpack-dev-server` when launching Webpack. Use the `WEBPACK_DEV_SERVER` environment to configure a different NPM package name, such as a private fork of this package.
+
+## See also
+
+- [@rushstack/heft-jest-plugin](https://github.com/microsoft/rushstack/tree/main/heft-plugins/heft-jest-plugin)
+- [@rushstack/heft-webpack5-plugin](https://github.com/microsoft/rushstack/tree/main/heft-plugins/heft-webpack5-plugin)
+- [@rushstack/heft-webpack4-plugin](https://github.com/microsoft/rushstack/tree/main/heft-plugins/heft-webpack4-plugin)

--- a/websites/rushstack.io/docs/pages/heft_tutorials/getting_started.md
+++ b/websites/rushstack.io/docs/pages/heft_tutorials/getting_started.md
@@ -145,6 +145,11 @@ We'll begin by creating a simple standalone project without Rush. (Later, the [I
 
    > Some terminology: When we invoke the `heft build` command from the shell, the "build" verb is called an **action**. Actions are user interface concepts, sort of like macros. The action causes Heft to invoke multiple **tasks** such as `[typescript]` or `[copy-static-assets]`. These tasks often run in parallel. The tasks are grouped into **stages** such as "Compile" and "Bundle" in the above log. Stages represent major steps of the overall operation. These concepts are explained in more depth in the [Heft architecture](../heft/architecture.md) article.
 
+   > NOTE: When reporting diagnostic messages such as a compile error, Heft prints file paths relative
+   > to the project folder. This can be customized using the
+   > [RUSHSTACK_FILE_ERROR_BASE_FOLDER](../heft_configs/environment_vars.md#rushstack_file_error_base_folder)
+   > environment variable.
+
    After the build finishes, confirm that it produced several output files in your `lib` folder:
 
    - **start.js** - the compiled JavaScript code

--- a/websites/rushstack.io/sidebars.js
+++ b/websites/rushstack.io/sidebars.js
@@ -118,6 +118,7 @@ const sidebars = {
       label: 'Heft config files',
       collapsible: false,
       items: [
+        'pages/heft_configs/environment_vars',
         'pages/heft_configs/api-extractor-task_json',
         'pages/heft_configs/heft_json',
         'pages/heft_configs/node-service_json',


### PR DESCRIPTION
We also need to document `RUSHSTACK_FILE_ERROR_BASE_FOLDER` in the `node-core-library` API docs, but I'll make a separate PR for that.