### PR TITLE
fix: improve translation of zh-CN .npmrc docs

### DIFF
--- a/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/configs/npmrc.md
+++ b/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/configs/npmrc.md
@@ -7,8 +7,8 @@ title: .npmrc
 **common/config/rush/.npmrc**
 
 ```shell
-# Rush 使用该文件来配置安装阶段的 NPM 源，它可以用 PNPM, NPM 或者 Yarn. 它被诸如 "rush install",
-# "rush update", "install-run.js" 脚本等使用。
+# Rush 使用该文件来配置安装阶段的 NPM 源，它可以用 PNPM，NPM 或者 Yarn。它被诸如 "rush install",
+# "rush update"，"install-run.js" 脚本等使用。
 #
 # 注意： "rush publish" 命令使用 .npmrc-publish 文件。
 #
@@ -31,14 +31,14 @@ always-auth=false
 普通 Rush 操作执行如下查找：
 
 1. 为了支持不规范的情况，NPM 配置的环境变量优先于任何 **.npmrc** 配置。环境变量名以 `npm_config_` 开头，例如设置 `npm_config_registry` 可以覆盖 **.npmrc** 中的 `registry` 设置。NPM 的设计中也可以 i 接受不规范的命名，例如 `npm_config_@example:registry`.
-2. 通常的配置刚来自于 Rush 拷贝到工作目录的临时文件 **.npmrc**, 这个文件拷贝自 **common/config/rush/.npmrc**, 但是省略了很多没有定义的环境变量（解释如上）。对于更多操作。工作目录是 **common/temp**。
-3. 如果包管理器没有从方法 1 或方法 2 中找到配置项，将使用用户中的 **～/.npmrc**. 用户通常存储自己的身份验证令牌在这个文件中。
+2. 通常的配置刚来自于 Rush 拷贝到工作目录的临时文件 **.npmrc**，这个文件拷贝自 **common/config/rush/.npmrc**，但是省略了很多没有定义的环境变量（解释如上）。对于大多数的操作，工作目录是 **common/temp**。
+3. 如果包管理器没有从方法 1 或方法 2 中找到配置项，将使用用户配置中的 **~/.npmrc**。用户通常存储自己的身份验证令牌在这个文件中。
 
 以上规则同样适用于诸如 **install-run.js** 等辅助脚本。
 
-`rush publish` 可以使用不同 **.npmrc-publish**, 。详细请参考[此文档](../configs/npmrc-publish.md)。
+`rush publish` 使用独立的 **.npmrc-publish** 配置文件。详细请参考[此文档](../configs/npmrc-publish.md)。
 
-当包管理器直接被调用时（而不是通过 Rush），那么上述规则不适用。例如，从 shell 中调用 `npm publish`, 之后将使用[包管理器的通常优先级](https://docs.npmjs.com/cli/v7/using-npm/config#npmrc-files)。通常不鼓励上述行为，你可以创建额外的 **.npmrc** 文件。
+上述规则不适用于直接调用 Rush 以外的包管理器的情况。例如，从 shell 中调用 `npm publish`时，将按照[包管理器的通常优先级](https://docs.npmjs.com/cli/v7/using-npm/config#npmrc-files)寻找 **.npmrc** 文件。通常不鼓励在 Rush 仓库中执行上述行为。当执行上述行为时，你可能需要创建额外的 **.npmrc** 文件。
 
 ## 参考
 


### PR DESCRIPTION
Improve translation of `.npmrc` docs page in Simplified Chinese.

Major changes:

- Correct punctuations.
- Missing phrases: e.g. "in a Rush repo" and "but if used"
- Wrong translations: e.g. "most" in "for most operations" was translated to "更多的 *(lit. more)* ". "may" in "you may need to create additional .npmrc files." was translated to "可以 *(lit. can, be able to)* " which should be "可能需要 *(lit. have to do something possibly)* "