### PR TITLE
Add a redirect link for https://rushstack.io/link/heft-0.51

### DIFF
--- a/websites/rushstack.io/docs/link/heft-0.51.md
+++ b/websites/rushstack.io/docs/link/heft-0.51.md
@@ -1,0 +1,10 @@
+---
+custom_edit_url:
+hide_title: true
+---
+
+Redirecting...
+
+<head>
+  <meta http-equiv="refresh" content="1; url=https://github.com/microsoft/rushstack/blob/main/apps/heft/UPGRADING.md#heft-0510" />
+</head>


### PR DESCRIPTION
This link is printed when an outdated config file is detected:

https://github.com/microsoft/rushstack/pull/4177
```
PS D:\Work\rushstack3\libraries\rush-lib> node .\node_modules\@rushstack\heft\bin\heft build
Error: This project's Heft configuration appears to be using an outdated schema.

Heft 0.51.0 introduced a major breaking change for Heft configuration files. Your project appears 
to be using the older file format.  You will need to migrate your project to the new format. 
Follow these instructions: https://rushstack.io/link/heft-0.51
```

For now it will just redirect to UPGRADING.md.

However I'm going to see if we can enable the Docusuarus "blog" feature so we can have articles
for these sorts of events.