### PR TITLE
[rushstack] Support "invitation only" events

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -492,7 +492,6 @@ importers:
       '@docusaurus/types': 2.3.1
       '@mdx-js/react': ~1.6.22
       '@svgr/webpack': ~6.3.1
-      '@types/history': 5.0.0
       '@types/js-cookie': 3.0.2
       '@types/node': 16.18.12
       '@types/react': ^17.0.2
@@ -538,7 +537,6 @@ importers:
       '@babel/core': 7.18.13
       '@babel/runtime': 7.17.9
       '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
-      '@types/history': 5.0.0
       '@types/js-cookie': 3.0.2
       '@types/node': 16.18.12
       '@types/react': 17.0.53
@@ -3907,13 +3905,6 @@ packages:
   /@types/history/4.7.11:
     resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
 
-  /@types/history/5.0.0:
-    resolution: {integrity: sha512-hy8b7Y1J8OGe6LbAjj3xniQrj3v6lsivCcrmf4TzSgPzLkhIeKgc5IZnT7ReIqmEuodjfO8EYAuoFvIrHi/+jQ==}
-    deprecated: This is a stub types definition. history provides its own type definitions, so you do not need this installed.
-    dependencies:
-      history: 5.3.0
-    dev: true
-
   /@types/html-minifier-terser/6.1.0:
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
 
@@ -6927,12 +6918,6 @@ packages:
       tiny-invariant: 1.3.1
       tiny-warning: 1.0.3
       value-equal: 1.0.1
-
-  /history/5.3.0:
-    resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
-    dependencies:
-      '@babel/runtime': 7.17.9
-    dev: true
 
   /hoist-non-react-statics/3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}

--- a/websites/rushstack.io/package.json
+++ b/websites/rushstack.io/package.json
@@ -43,7 +43,6 @@
     "@babel/core": "~7.18.10",
     "@babel/runtime": "~7.17.9",
     "@docusaurus/types": "2.3.1",
-    "@types/history": "5.0.0",
     "@types/js-cookie": "3.0.2",
     "@types/node": "16.18.12",
     "@types/react-dom": "^17.0.2",

--- a/websites/rushstack.io/src/rscommunity/api/ApiInterfaces.ts
+++ b/websites/rushstack.io/src/rscommunity/api/ApiInterfaces.ts
@@ -11,10 +11,12 @@ export type AssertType<T1 extends { [P2 in keyof T2]: T2[P2] }, T2 extends { [P1
 
 export type ApiEventStatus = 'NEW' | 'CANCELLED' | 'RESCHEDULED' | 'DONE';
 
+export type ApiDate = string;
+
 export type IApiTableEvent = {
   dbEventId: number;
   eventTitle: string;
-  startTime: Date | undefined;
+  startTime: ApiDate | undefined;
   duration: number | undefined;
   durationUnits: string;
   hostedBy: string;
@@ -29,7 +31,7 @@ export type IApiTableEvent = {
 
 export type IApiTableHistory = {
   dbHistoryId: number;
-  timestamp: Date;
+  timestamp: ApiDate;
   dbUserId: number | undefined;
   username: string;
   dbEventId: number | undefined;
@@ -40,8 +42,8 @@ export type IApiTableHistory = {
 export type IApiTableRegistration = {
   dbEventId: number;
   dbUserId: number;
-  signupTimestamp: Date;
-  cancelTimestamp: Date | undefined;
+  signupTimestamp: ApiDate;
+  cancelTimestamp: ApiDate | undefined;
 };
 
 export type IApiTableUser = {
@@ -76,6 +78,7 @@ export type IApiTableUser = {
 
 export type IApiEvent = IApiTableEvent & {
   spotsLeftNotice: string;
+  invitationOnly: boolean;
   userIsSignedUp: boolean;
 };
 

--- a/websites/rushstack.io/src/rscommunity/view/EventCard.tsx
+++ b/websites/rushstack.io/src/rscommunity/view/EventCard.tsx
@@ -154,7 +154,13 @@ export class EventCard extends React.Component<IEventCardProps> {
 
     if (!apiEvent.isCompleted) {
       // UPCOMING EVENT
-      if (apiEvent.userIsSignedUp) {
+      if (apiEvent.invitationOnly) {
+        spotsLeftDiv = (
+          <div style={{ paddingTop: '20px', fontWeight: 'bold' }}>
+            Online signup is not available for this event.
+          </div>
+        );
+      } else if (apiEvent.userIsSignedUp) {
         footnote = <>You are attending this event</>;
 
         if (this.props.cardType === 'summary') {


### PR DESCRIPTION
If `totalSpots` is configured as `0` then the rscommunity signup app will display a notice saying `Online signup is not available for this event`. Participants must request an invitation from the event organizer.