### PR TITLE
[rushstack] Enable logged out preview

### DIFF
--- a/websites/rushstack.io/docs/index.md
+++ b/websites/rushstack.io/docs/index.md
@@ -72,4 +72,4 @@ In summer of 2019, we launched **Rush Stack** with the aim to provide a reusable
 
 <!-- Verification of Mastodon account -->
 
-<a rel="me" class="no-external-link-icon" href="https://fosstodon.org/@rushstack"></a>
+<a rel="me" className="no-external-link-icon" href="https://fosstodon.org/@rushstack"></a>

--- a/websites/rushstack.io/src/pages/community/events.tsx
+++ b/websites/rushstack.io/src/pages/community/events.tsx
@@ -26,13 +26,9 @@ class EventsPageBody extends React.Component {
   }
 
   public render(): JSX.Element {
-    if (!this._appSession.loggedInUser) {
-      return <CommunitySignInPage appSession={this._appSession} />;
-    }
-
     const eventTask: ApiTask<EventModel[]> = this._appSession.apiDataService.initiateGetEvents(
       this,
-      'current'
+      this._appSession.loggedInUser ? 'current' : 'preview'
     );
 
     if (eventTask.status === ApiTaskStatus.Error) {
@@ -50,6 +46,7 @@ class EventsPageBody extends React.Component {
           {eventModels.map((eventModel) => (
             <EventCard
               cardType="summary"
+              loggedOutPreview={!this._appSession.loggedInUser}
               eventModel={eventModel}
               apiDataService={this._appSession.apiDataService}
               key={eventModel.apiEvent.dbEventId}

--- a/websites/rushstack.io/src/rscommunity/api/ApiDataService.ts
+++ b/websites/rushstack.io/src/rscommunity/api/ApiDataService.ts
@@ -91,13 +91,25 @@ export class ApiDataService {
     });
   }
 
-  public initiateGetEvents(component: React.Component, filter: 'past' | 'current'): ApiTask<EventModel[]> {
+  public initiateGetEvents(
+    component: React.Component,
+    filter: 'past' | 'current' | 'preview'
+  ): ApiTask<EventModel[]> {
     const apiTaskKey: string = `events:${filter}`;
     return this._startApiTask(apiTaskKey, component, async () => {
-      this._requireLoggedIn();
+      if (filter !== 'preview') {
+        this._requireLoggedIn();
+      }
       console.log('Fetching events...');
 
-      const data: Response = await fetch(`${this.appSession.serviceUrl}/api/events?filter=${filter}`, {
+      let url: string;
+      if (filter === 'preview') {
+        url = `${this.appSession.serviceUrl}/api/events-preview`;
+      } else {
+        url = `${this.appSession.serviceUrl}/api/events?filter=${filter}`;
+      }
+
+      const data: Response = await fetch(url, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include'

--- a/websites/rushstack.io/src/rscommunity/api/AppSession.ts
+++ b/websites/rushstack.io/src/rscommunity/api/AppSession.ts
@@ -54,8 +54,11 @@ export class AppSession {
     return `/community/event?id=${eventId}`;
   }
 
-  public navigateToEventDetailPage(eventId: number): void {
-    const url: string = this.getEventDetailPageUrl(eventId);
+  public navigateToEventDetailPage(eventId: number, requireLogin?: boolean): void {
+    let url: string = this.getEventDetailPageUrl(eventId);
+    if (requireLogin) {
+      url += '&login';
+    }
     this.navigateToPage(url);
   }
 

--- a/websites/rushstack.io/src/rscommunity/api/models.ts
+++ b/websites/rushstack.io/src/rscommunity/api/models.ts
@@ -14,6 +14,10 @@ export class EventModel {
     this.appSession.navigateToEventDetailPage(this.apiEvent.dbEventId);
   };
 
+  public onNavigateToEventDetailPageRequireLogin = (): void => {
+    this.appSession.navigateToEventDetailPage(this.apiEvent.dbEventId, true);
+  };
+
   public onAddReservation = (): void => {
     this.appSession.apiDataService.addReservationAsync(this).catch((error) => {
       console.error((error as Error).toString());

--- a/websites/rushstack.io/src/rscommunity/view/CommunitySidebar.tsx
+++ b/websites/rushstack.io/src/rscommunity/view/CommunitySidebar.tsx
@@ -77,13 +77,14 @@ export function CommunitySidebar(props: React.PropsWithChildren<ICommunitySideba
               paddingTop: '50px'
             }}
           >
-            ⚠{' '}
             <i>
-              This feature is experimental. Please{' '}
-              <a href="https://github.com/microsoft/rushstack-websites/issues" target="_blank">
-                let us know
-              </a>{' '}
-              if anything is broken.
+              <div>
+                If you have questions or problems regarding event sign-ups, let us know in the{' '}
+                <a href="https://rushstack.zulipchat.com/#narrow/stream/296580-rush-hour" target="_blank">
+                  #rush-hour
+                </a>{' '}
+                chat room.
+              </div>
             </i>
           </div>
         </div>

--- a/websites/rushstack.io/src/rscommunity/view/EventCard.tsx
+++ b/websites/rushstack.io/src/rscommunity/view/EventCard.tsx
@@ -102,6 +102,7 @@ export function EventCardBody(props: {
 
 interface IEventCardProps {
   cardType: 'summary' | 'detail';
+  loggedOutPreview?: boolean;
   eventModel: EventModel;
   apiDataService: ApiDataService;
 }
@@ -160,6 +161,13 @@ export class EventCard extends React.Component<IEventCardProps> {
             Online signup is not available for this event.
           </div>
         );
+      } else if (this.props.loggedOutPreview) {
+        actionButton = (
+          <DecoratedButton onClick={eventModel.onNavigateToEventDetailPageRequireLogin}>
+            Sign in to learn more
+          </DecoratedButton>
+        );
+        // Don't show spotsLeftDiv for people who are not logged in
       } else if (apiEvent.userIsSignedUp) {
         footnote = <>You are attending this event</>;
 


### PR DESCRIPTION
The rscommunity web app was designed to minimize server load (e.g. from search crawlers), by avoiding any REST API calls unless the user is logged in via GitHub.

This PR relaxes that policy slightly so that a GitHub login is no longer required to view the "Upcoming Events" page, as well as the details of a current event.  Browsing past events still requires a login.

This is implemented using a new service endpoint `/events/api-preview`.

<kbd>

![image](https://github.com/microsoft/rushstack-websites/assets/4673363/9ac89a70-28d0-46cf-8f4f-ae72c5beaccd)

</kbd>