### PR TITLE
[rushstack] Add a Mastodon feed component to the "News" page

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -68,16 +68,21 @@ importers:
       '@docusaurus/types': 2.3.1
       '@rushstack/heft': ~0.49.7
       '@rushstack/heft-web-rig': ~0.14.5
+      '@types/dompurify': ^3.0.3
       '@types/heft-jest': ~1.0.3
       '@types/node': 16.18.12
       '@types/react': ^17.0.2
       '@types/react-dom': ^17.0.2
+      dayjs: ~1.11.4
+      dompurify: ^3.0.6
       react: ^17.0.2
       react-dom: ^17.0.2
       tslib: ^2.4.0
       typescript: ~4.7.4
     dependencies:
       '@docusaurus/core': 2.3.1_3tgeifm2vmwrlpqlopppsnjtcu
+      dayjs: 1.11.7
+      dompurify: 3.0.6
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       tslib: 2.5.0
@@ -85,6 +90,7 @@ importers:
       '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
       '@rushstack/heft': 0.49.7_@types+node@16.18.12
       '@rushstack/heft-web-rig': 0.14.5_5hykmn7vfxz5xqj34k2r5ezzia
+      '@types/dompurify': 3.0.3
       '@types/heft-jest': 1.0.3
       '@types/node': 16.18.12
       '@types/react': 17.0.53
@@ -3855,6 +3861,12 @@ packages:
     dependencies:
       '@types/node': 16.18.12
 
+  /@types/dompurify/3.0.3:
+    resolution: {integrity: sha512-odiGr/9/qMqjcBOe5UhcNLOFHSYmKFOyr+bJ/Xu3Qp4k1pNPAlNLUVNNLcLfjQI7+W7ObX58EdD3H+3p3voOvA==}
+    dependencies:
+      '@types/trusted-types': 2.0.4
+    dev: true
+
   /@types/eslint-scope/3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
@@ -4054,6 +4066,10 @@ packages:
 
   /@types/tough-cookie/4.0.2:
     resolution: {integrity: sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==}
+    dev: true
+
+  /@types/trusted-types/2.0.4:
+    resolution: {integrity: sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ==}
     dev: true
 
   /@types/unist/2.0.6:
@@ -5776,6 +5792,10 @@ packages:
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
+    dev: false
+
+  /dompurify/3.0.6:
+    resolution: {integrity: sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w==}
     dev: false
 
   /domutils/2.8.0:

--- a/plugins/theme-rushstack-suite-nav/package.json
+++ b/plugins/theme-rushstack-suite-nav/package.json
@@ -12,12 +12,15 @@
     "@docusaurus/core": "2.3.1",
     "react-dom": "^17.0.2",
     "react": "^17.0.2",
+    "dayjs": "~1.11.4",
+    "dompurify": "^3.0.6",
     "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@docusaurus/types": "2.3.1",
     "@rushstack/heft-web-rig": "~0.14.5",
     "@rushstack/heft": "~0.49.7",
+    "@types/dompurify": "^3.0.3",
     "@types/heft-jest": "~1.0.3",
     "@types/node": "16.18.12",
     "@types/react-dom": "^17.0.2",

--- a/plugins/theme-rushstack-suite-nav/src/components/MastodonFeed.module.css
+++ b/plugins/theme-rushstack-suite-nav/src/components/MastodonFeed.module.css
@@ -1,0 +1,118 @@
+.feed {
+  color: #ffffff;
+  background-color: #282c37;
+  max-width: 600px;
+  border-radius: 6px;
+}
+
+.feedHeader {
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  color: #ffffff;
+  text-align: right;
+}
+.feedHeader a {
+  color: #ffffff;
+}
+
+.statusPrepend {
+  display: flex;
+  flex-direction: row;
+  column-gap: 10px;
+  align-items: center;
+  padding-bottom: 16px;
+
+  font-weight: 700;
+  color: #606984;
+}
+
+.status {
+  border-color: #393f4f;
+  border-top-style: solid;
+  border-top-width: 1px;
+  padding: 16px;
+
+  cursor: pointer;
+}
+
+.status_info {
+  padding-bottom: 10px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.status_relativeTime {
+  color: #606984;
+  flex-basis: auto;
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.status_relativeTime:hover {
+  color: #606984;
+}
+
+.status_displayName {
+  align-items: center;
+  display: flex;
+  color: #ffffff;
+  column-gap: 10px;
+}
+
+.status_displayName:hover {
+  text-decoration: none;
+  color: #ffffff;
+}
+
+.displayName_html {
+  font-weight: 700;
+}
+
+.displayName_html:hover {
+  text-decoration: underline;
+  color: #ffffff;
+}
+
+.displayName_account {
+  color: #606984;
+}
+.displayName_account:hover {
+  color: #606984;
+}
+
+.status_avatar {
+  align-items: center;
+  display: flex;
+  font-size: 15px;
+  font-weight: 400;
+  height: 46px;
+  width: 46px;
+  border-radius: 4px;
+}
+
+.status_content {
+}
+
+.status_content a {
+  color: #8c8dff;
+}
+
+.status_content :global(.mention) {
+  color: #d9e1e8;
+}
+
+.media_gallery {
+  border-radius: 8px;
+}
+
+.mastodonIcon_boost {
+  width: 20px;
+  height: 20px;
+  background-image: url('data:image/svg+xml,%3Csvg%20width%3D%2220.639025%22%20height%3D%2212.692221%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22m4.2439268%200.02472098c-0.1%200.03-0.17%200.1-0.22%200.18l-3.95%204.9c-0.2%200.3%200.03%200.78%200.4%200.8h2.4v2.68c0%204.26-0.55%203.62%203.66%203.62h7.6600002l-2.3-2.84c-0.03-0.02-0.03-0.04-0.05-0.06h-5.3000002c-0.44%200-0.72-0.3-0.72-0.72v-2.7h2.5c0.37%200.03%200.63-0.48%200.4-0.77l-3.95-4.9c-0.12-0.17-0.34-0.25-0.53-0.2zm12.16%200.43c-0.55-0.02-1.32%200.02-2.4%200.02h-7.6300002l2.32%202.85%200.03%200.06h5.2500002c0.42%200%200.72%200.28%200.72%200.72v2.7h-2.5c-0.36%200.02-0.56%200.54-0.3%200.8l3.92%204.9c0.18%200.25%200.6%200.25%200.78%200l3.94-4.9c0.26-0.28%200-0.83-0.37-0.8h-2.49v-2.7c0-3.15%200.4-3.62-1.25-3.66z%22%20fill%3D%22%23606984%22%20stroke-width%3D%220%22%2F%3E%3C%2Fsvg%3E');
+  background-repeat: no-repeat;
+  background-position: center center;
+}

--- a/plugins/theme-rushstack-suite-nav/src/components/MastodonFeed.module.css
+++ b/plugins/theme-rushstack-suite-nav/src/components/MastodonFeed.module.css
@@ -12,7 +12,12 @@
   padding-bottom: 4px;
   color: #ffffff;
   text-align: right;
+
+  border-color: #393f4f;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
 }
+
 .feedHeader a {
   color: #ffffff;
 }
@@ -30,8 +35,8 @@
 
 .status {
   border-color: #393f4f;
-  border-top-style: solid;
-  border-top-width: 1px;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
   padding: 16px;
 
   cursor: pointer;
@@ -115,4 +120,22 @@
   background-image: url('data:image/svg+xml,%3Csvg%20width%3D%2220.639025%22%20height%3D%2212.692221%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22m4.2439268%200.02472098c-0.1%200.03-0.17%200.1-0.22%200.18l-3.95%204.9c-0.2%200.3%200.03%200.78%200.4%200.8h2.4v2.68c0%204.26-0.55%203.62%203.66%203.62h7.6600002l-2.3-2.84c-0.03-0.02-0.03-0.04-0.05-0.06h-5.3000002c-0.44%200-0.72-0.3-0.72-0.72v-2.7h2.5c0.37%200.03%200.63-0.48%200.4-0.77l-3.95-4.9c-0.12-0.17-0.34-0.25-0.53-0.2zm12.16%200.43c-0.55-0.02-1.32%200.02-2.4%200.02h-7.6300002l2.32%202.85%200.03%200.06h5.2500002c0.42%200%200.72%200.28%200.72%200.72v2.7h-2.5c-0.36%200.02-0.56%200.54-0.3%200.8l3.92%204.9c0.18%200.25%200.6%200.25%200.78%200l3.94-4.9c0.26-0.28%200-0.83-0.37-0.8h-2.49v-2.7c0-3.15%200.4-3.62-1.25-3.66z%22%20fill%3D%22%23606984%22%20stroke-width%3D%220%22%2F%3E%3C%2Fsvg%3E');
   background-repeat: no-repeat;
   background-position: center center;
+}
+
+.feedFooter {
+  display: flex;
+  height: 30px;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #bbbbbb;
+  font-size: 10px;
+}
+
+.feedFooter:hover {
+  background-color: #313543;
+}
+
+.feedFooterLink:hover {
+  text-decoration: none;
 }

--- a/plugins/theme-rushstack-suite-nav/src/components/MastodonFeed.tsx
+++ b/plugins/theme-rushstack-suite-nav/src/components/MastodonFeed.tsx
@@ -1,0 +1,257 @@
+import React, { useState, useEffect } from 'react';
+import dayjs from 'dayjs';
+import DOMPurify from 'dompurify';
+
+import styles from './MastodonFeed.module.css';
+
+/**
+ * A Mastodon post object, with just the fields of posts that we need.
+ */
+interface IPostJson {
+  id: string;
+  created_at: string;
+  in_reply_to_id: string | null;
+  content: string;
+  url: string;
+  account: {
+    username: string;
+    display_name: string;
+    avatar: string;
+    url: string;
+  };
+  reblog?: IPostJson;
+  media_attachments: {
+    type: 'unknown' | 'image' | 'gifv' | 'video' | 'audio';
+    url: string;
+    preview_url: string;
+    description: string;
+    blurhash: string;
+  }[];
+}
+
+export interface ILoadPostsOptions {
+  /**
+   * Example: `https://mastodon.social/@Mastodon`
+   */
+  userUrl: string;
+  /**
+   * Example: `109525862248474026`
+   */
+  mastodonUserId?: string;
+  maxFeedItems?: number;
+  includeReplies?: boolean;
+}
+
+/**
+ * Get the posts for an HTML element and replace that element with the
+ * rendered post list.
+ */
+export async function loadPosts(options: ILoadPostsOptions): Promise<IPostJson[]> {
+  const userURL: URL = new URL(options.userUrl);
+
+  // Get the user ID, either from an explicit `data-post-account-id` attribute
+  // or by looking it up based on the username in the link.
+  const userId: string =
+    options.mastodonUserId ??
+    (await (async () => {
+      // Extract username from URL.
+      const parts = /@(\w+)$/.exec(userURL.pathname);
+      if (!parts) {
+        throw Error('not a Mastodon user URL');
+      }
+      const username = parts[1];
+
+      // Look up user ID from username.
+      const lookupURL = Object.assign(new URL(userURL), {
+        pathname: '/api/v1/accounts/lookup',
+        search: `?acct=${username}`
+      });
+      return (await (await fetch(lookupURL)).json())['id'];
+    })());
+
+  const maxFeedItems: number = options.maxFeedItems ?? 5;
+  const includeReplies: boolean = options.includeReplies ?? false;
+  const postURL = Object.assign(new URL(userURL), {
+    pathname: `/api/v1/accounts/${userId}/statuses`,
+    search: `?limit=${maxFeedItems}&exclude_replies=${!includeReplies}`
+  });
+  const posts: IPostJson[] = await (await fetch(postURL)).json();
+  return posts;
+}
+
+interface IMastodonPostProps {
+  post: IPostJson;
+  userUrl: string;
+}
+
+export function MastodonPost(props: IMastodonPostProps): JSX.Element {
+  let outerPost: IPostJson = props.post;
+
+  let post: IPostJson = outerPost;
+
+  // Is this a boost (reblog)?
+  if (outerPost.reblog) {
+    post = outerPost.reblog; // Render the boosted post instead
+  }
+
+  const outerPostPageUrl: string = `${props.userUrl}/${outerPost.id}`;
+
+  const nowTime: dayjs.Dayjs = dayjs();
+  const createdAtTime: dayjs.Dayjs = dayjs(new Date(outerPost.created_at));
+  const hoursAgo: number = nowTime.diff(createdAtTime, 'hour');
+  let relativeTime: string;
+
+  if (hoursAgo < 24) {
+    // On the same day: "15h"
+    relativeTime = `${hoursAgo}h`;
+  } else if (nowTime.isSame(createdAtTime, 'year')) {
+    // On the same year: "Jan 12"
+    relativeTime = createdAtTime.format('MMM D');
+  } else {
+    // Otherwise: "Jan 12, 2023"
+    relativeTime = createdAtTime.format('MMM D, YYYY');
+  }
+
+  const images = post.media_attachments.filter((att) => att.type === 'image');
+
+  const safeHtml: string = DOMPurify.sanitize(post.content);
+
+  const statusPrepend: JSX.Element | undefined = outerPost.reblog ? (
+    <div className={styles.statusPrepend}>
+      <div className={styles.mastodonIcon_boost}></div>
+      <div>
+        <a
+          className={[styles.displayName_account, 'no-external-link-icon'].join(' ')}
+          target="_blank"
+          rel="noopener noreferrer"
+          href={outerPost.account.url}
+        >
+          {outerPost.account.display_name}
+        </a>{' '}
+        boosted
+      </div>
+    </div>
+  ) : undefined;
+
+  function status_onClick(event: React.MouseEvent<HTMLDivElement>) {
+    // Did we click on something that is not under an <a> tag?
+    if (!(event.target as HTMLElement).closest('a')) {
+      window.open(outerPostPageUrl, '_blank');
+    }
+  }
+
+  return (
+    <div className={styles.status} onClick={status_onClick}>
+      {statusPrepend}
+      <div className={styles.status_info}>
+        <a
+          className={[styles.status_displayName, 'no-external-link-icon'].join(' ')}
+          target="_blank"
+          rel="noopener noreferrer"
+          href={post.account.url}
+        >
+          <img className={styles.status_avatar} width={46} height={46} src={post.account.avatar} />
+          <div>
+            <div className={styles.displayName_html}>{post.account.display_name}</div>
+            <div className={styles.displayName_account}>@{post.account.username}</div>
+          </div>
+        </a>
+        <a
+          className={[styles.status_relativeTime, 'no-external-link-icon'].join(' ')}
+          target="_blank"
+          rel="noopener noreferrer"
+          href={outerPostPageUrl}
+        >
+          <time dateTime={outerPost.created_at}>{relativeTime}</time>
+        </a>
+      </div>
+      <div className={styles.status_content} dangerouslySetInnerHTML={{ __html: safeHtml }}></div>
+      {images.map((att) => (
+        <a className="no-external-link-icon" href={att.url} target="_blank" rel="noopener noreferrer">
+          <img className={styles.media_gallery} src={att.preview_url} alt={att.description} />
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export interface IMastodonFeedProps {
+  /**
+   * Example: `@rushstack@fosstodon.org`
+   */
+  mastodonUserFullName: string;
+  /**
+   * Example: `109525862248474026`
+   */
+  mastodonUserId?: string;
+  maxFeedItems?: number;
+  includeReplies?: boolean;
+}
+
+type FetchState =
+  | undefined
+  | {
+      state: 'error';
+      error: Error;
+    }
+  | { state: 'loaded'; posts: IPostJson[] };
+
+export function MastodonFeed(props: IMastodonFeedProps): JSX.Element {
+  const [fetchState, setFetchState] = useState<FetchState>(undefined);
+
+  const parsedMastodonUserFullName: string[] = props.mastodonUserFullName.split('@');
+  // Example: "@rushstack@fosstodon.org" --> "rushstack"
+  const mastodonUserPart: string = parsedMastodonUserFullName[1] ?? '';
+  // Example: "@rushstack@fosstodon.org" --> "fosstodon.org"
+  const mastodonServerPart: string = parsedMastodonUserFullName[2] ?? '';
+  if (!mastodonUserPart || !mastodonServerPart) {
+    throw Error('Invalid mastodonUserFullName');
+  }
+  const userUrl: string = `https://${mastodonServerPart}/@${mastodonUserPart}`;
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const posts: IPostJson[] = await loadPosts({
+          userUrl,
+          includeReplies: props.includeReplies,
+          mastodonUserId: props.mastodonUserId,
+          maxFeedItems: props.maxFeedItems
+        });
+        setFetchState({ state: 'loaded', posts });
+      } catch (error) {
+        debugger;
+        setFetchState({ state: 'error', error: error as Error });
+      }
+    })();
+  }, [props.mastodonUserFullName, props.includeReplies, props.maxFeedItems, props.mastodonUserId]);
+
+  const posts: IPostJson[] = [];
+  let missingPostsNotice: string | undefined;
+
+  if (fetchState === undefined) {
+    missingPostsNotice = '. . .';
+  } else if (fetchState.state === 'error') {
+    missingPostsNotice = `Error: ${fetchState.error.message}`;
+  } else {
+    posts.push(...fetchState.posts);
+    if (posts.length === 0) {
+      missingPostsNotice = '(The feed is empty.)';
+    }
+  }
+
+  return (
+    <div className={[styles.feed, 'no-external-link-icon'].join(' ')}>
+      <div className={styles.feedHeader}>
+        Mastodon feed for{' '}
+        <a className="no-external-link-icon" target="_blank" rel="noopener noreferrer" href={userUrl}>
+          {props.mastodonUserFullName}
+        </a>
+      </div>
+      {missingPostsNotice ? <div className={styles.status}>{missingPostsNotice}</div> : undefined}
+      {posts.map((post, index) => (
+        <MastodonPost key={index} post={post} userUrl={userUrl} />
+      ))}
+    </div>
+  );
+}

--- a/plugins/theme-rushstack-suite-nav/src/components/MastodonFeed.tsx
+++ b/plugins/theme-rushstack-suite-nav/src/components/MastodonFeed.tsx
@@ -252,6 +252,15 @@ export function MastodonFeed(props: IMastodonFeedProps): JSX.Element {
       {posts.map((post, index) => (
         <MastodonPost key={index} post={post} userUrl={userUrl} />
       ))}
+      <a
+        className={[styles.feedFooterLink, 'no-external-link-icon'].join(' ')}
+        target="_blank"
+        rel="noopener noreferrer"
+        href={userUrl}
+      >
+        <div className={styles.feedFooter}> • &nbsp; • &nbsp; • </div>
+      </a>
     </div>
   );
 }
+// 🞃

--- a/plugins/theme-rushstack-suite-nav/tsconfig.json
+++ b/plugins/theme-rushstack-suite-nav/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "./node_modules/@rushstack/heft-web-rig/profiles/library/tsconfig-base.json",
   "compilerOptions": {
     "types": ["node", "heft-jest"],
+    "target": "ES2020",
+    "lib": ["ESNext", "scripthost", "es2015.collection", "es2015.promise", "es2015.iterable", "dom"],
     "importHelpers": true,
     "noEmitHelpers": true
   }

--- a/websites/api-extractor.com/docs/pages/news.md
+++ b/websites/api-extractor.com/docs/pages/news.md
@@ -2,6 +2,8 @@
 title: What's new
 ---
 
+import { MastodonFeed } from 'theme-rushstack-suite-nav/lib/components/MastodonFeed';
+
 To find out what's changed in the latest release, please see the package changelogs:
 
 - [@microsoft/api-extractor changelog](https://github.com/microsoft/rushstack/blob/main/apps/api-extractor/CHANGELOG.md)
@@ -11,50 +13,8 @@ To find out what's changed in the latest release, please see the package changel
 API Extractor is maintained by the Rush Stack developer community. For roadmaps and updates from the team,
 please visit the [Rush Stack News](https://rushstack.io/pages/news/) page.
 
-There's also a [@rushstack](https://twitter.com/rushstack) Twitter feed.
+## Announcements
 
-## Important Updates
+Follow us on [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack) or [Twitter (@rushstack)](https://twitter.com/rushstack).
 
-### API Extractor 7 is out! 🎉
-
-After nearly 6 months of "beta" releases, we're excited to announce that API Extractor 7
-is finally ready for general usage! Since the beta releases used the 7.0.x version numbers,
-we're using 7.1.0 for the first stable release.
-
-### Big changes in Version 7
-
-Version 7 represents a major overhaul of the analysis engine: In the past, API Extractor used a relatively
-simple analyzer that required special parsers/writers to be coded for each supported declaration type
-(classes, enums, interfaces, etc). This worked because of an assumption that your code base restricted itself
-to a small set of recommended TypeScript language features. When we introduced the .d.ts rollup feature, it suddenly
-became important to perfectly handle all sorts of expressions, since otherwise the generated .d.ts rollup
-would not compile. To address this, a new, much more flexible analyzer was designed. In API Extractor 6,
-this new analyzer is not used for API reports or documentation. It had trouble with a lot of projects, but that
-wasn't a big deal, since you could simply disable the .d.ts rollup feature for those projects. Starting with
-API Extractor 7, the new analyzer is used for everything. This is a big architectural improvement, but now
-there's no fallback if it can't handle certain projects. Thus, version 7 was in "beta" for several months while
-we ironed out every last bugs and edge case until several major real world monorepos could finally build successfully.
-
-In addition to this, API Extractor brings a bunch of other cool enhancements:
-
-- Each warning, error, and console message has been assigned a "message ID"
-
-- Each message ID can be can individually suppressed or configured
-
-- The **api-extractor.json** config file format has been improved, and is now self-documenting
-
-- The API for invoking API Extractor programmatically has been greatly improved, and now includes a general
-  callback for intercepting all messages
-
-- The .api.json file format was completely redesigned, and we now provide a high-level library
-  **@microsoft/api-extractor-model** for loading, saving, and querying it
-
-- Support for TypeScript 3.4 in all its glory!
-
-### Upgrading from API Extractor 6
-
-The new config file schema is the most conspicuous breaking change. Fortunately, the overall concepts and operation
-mostly the same in Version 7, so upgrading **api-extractor.json** is a straightforward 1:1 mapping. Note that
-the interpretation of relative file paths has changed somewhat, though. Also, certain sections such as `"policies"`
-and `"validationRules"` are no longer needed. If you invoke API Extractor programmatically, the `Extractor` class
-has significant breaking changes, but it's well documented.
+<MastodonFeed mastodonUserFullName="@rushstack@fosstodon.org" mastodonUserId="109525862248474026" maxFeedItems="6" />

--- a/websites/api-extractor.com/src/css/custom.css
+++ b/websites/api-extractor.com/src/css/custom.css
@@ -144,7 +144,7 @@ html[data-theme='dark'] blockquote {
  * We only do this inside an <article> element.  Use the class="no-external-link-icon" to disable it.
  * An "external" page has "://" in its URL and does not include a recognized DNS name.
  */
-article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon)
+article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon):not(.avatar > *):not(.avatar__name > *):not(.mention)
 {
   background-position: center right;
   background-repeat: no-repeat;

--- a/websites/api.rushstack.io/src/css/custom.css
+++ b/websites/api.rushstack.io/src/css/custom.css
@@ -162,7 +162,7 @@ html[data-theme='dark'] blockquote {
  * We only do this inside an <article> element.  Use the class="no-external-link-icon" to disable it.
  * An "external" page has "://" in its URL and does not include a recognized DNS name.
  */
-article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon)
+article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon):not(.avatar > *):not(.avatar__name > *):not(.mention)
 {
   background-position: center right;
   background-repeat: no-repeat;

--- a/websites/heft.rushstack.io/docs/pages/support/news.md
+++ b/websites/heft.rushstack.io/docs/pages/support/news.md
@@ -2,6 +2,8 @@
 title: What's new
 ---
 
+import { MastodonFeed } from 'theme-rushstack-suite-nav/lib/components/MastodonFeed';
+
 To find out what's changed in the latest release, please see the Heft
 [CHANGELOG.md](https://github.com/microsoft/rushstack/blob/main/apps/heft/CHANGELOG.md).
 
@@ -16,6 +18,6 @@ The **Rush Hour** monthly video call is the easiest way to find out what's happe
 
 ## Announcements
 
-Follow us on [Twitter (@rushstack)](https://twitter.com/rushstack) or [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack)
+Follow us on [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack) or [Twitter (@rushstack)](https://twitter.com/rushstack).
 
-<div dangerouslySetInnerHTML={{__html: '<a class="twitter-timeline" data-width="600" tweet-limit="10" chrome="noscrollbar" data-dnt="true" data-link-color="#c95228" href="https://twitter.com/rushstack?ref_src=twsrc%5Etfw">Tweets by @rushstack</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>'}} />
+<MastodonFeed mastodonUserFullName="@rushstack@fosstodon.org" mastodonUserId="109525862248474026" maxFeedItems="6" />

--- a/websites/heft.rushstack.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/support/news.md
+++ b/websites/heft.rushstack.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/support/news.md
@@ -2,6 +2,8 @@
 title: 新功能
 ---
 
+import { MastodonFeed } from 'theme-rushstack-suite-nav/lib/components/MastodonFeed';
+
 To find out what's changed in the latest release, please see the Heft
 [CHANGELOG.md](https://github.com/microsoft/rushstack/blob/main/apps/heft/CHANGELOG.md).
 
@@ -16,6 +18,6 @@ The **Rush Hour** monthly video call is the easiest way to find out what's happe
 
 ## Announcements
 
-Follow us on [Twitter (@rushstack)](https://twitter.com/rushstack) or [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack)
+Follow us on [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack) or [Twitter (@rushstack)](https://twitter.com/rushstack).
 
-<div dangerouslySetInnerHTML={{__html: '<a class="twitter-timeline" data-width="600" tweet-limit="10" chrome="noscrollbar" data-dnt="true" data-link-color="#c95228" href="https://twitter.com/rushstack?ref_src=twsrc%5Etfw">Tweets by @rushstack</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>'}} />
+<MastodonFeed mastodonUserFullName="@rushstack@fosstodon.org" mastodonUserId="109525862248474026" maxFeedItems="6" />

--- a/websites/heft.rushstack.io/src/css/custom.css
+++ b/websites/heft.rushstack.io/src/css/custom.css
@@ -163,7 +163,7 @@ html[data-theme='dark'] blockquote {
  * An "external" page has "://" in its URL and does not include a recognized DNS name.
  * The `:not(.avatar > *)` and `:not(.avatar__name > *)` exclusions are for blog author details.
  */
-article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon):not(.avatar > *):not(.avatar__name > *)
+article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon):not(.avatar > *):not(.avatar__name > *):not(.mention)
 {
   background-position: center right;
   background-repeat: no-repeat;

--- a/websites/lfx.rushstack.io/docs/pages/support/news.md
+++ b/websites/lfx.rushstack.io/docs/pages/support/news.md
@@ -2,6 +2,8 @@
 title: What's new
 ---
 
+import { MastodonFeed } from 'theme-rushstack-suite-nav/lib/components/MastodonFeed';
+
 To find out what's changed in the latest release, please see the Lockfile Explorer
 [CHANGELOG.md](https://github.com/microsoft/rushstack/blob/main/apps/lockfile-explorer/CHANGELOG.md).
 
@@ -16,6 +18,6 @@ The **Rush Hour** monthly video call is the easiest way to find out what's happe
 
 ## Announcements
 
-Follow us on [Twitter (@rushstack)](https://twitter.com/rushstack) or [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack)
+Follow us on [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack) or [Twitter (@rushstack)](https://twitter.com/rushstack).
 
-<div dangerouslySetInnerHTML={{__html: '<a class="twitter-timeline" data-width="600" tweet-limit="10" chrome="noscrollbar" data-dnt="true" data-link-color="#c95228" href="https://twitter.com/rushstack?ref_src=twsrc%5Etfw">Tweets by @rushstack</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>'}} />
+<MastodonFeed mastodonUserFullName="@rushstack@fosstodon.org" mastodonUserId="109525862248474026" maxFeedItems="6" />

--- a/websites/lfx.rushstack.io/src/css/custom.css
+++ b/websites/lfx.rushstack.io/src/css/custom.css
@@ -144,7 +144,7 @@ html[data-theme='dark'] blockquote {
  * We only do this inside an <article> element.  Use the class="no-external-link-icon" to disable it.
  * An "external" page has "://" in its URL and does not include a recognized DNS name.
  */
-article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon)
+article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon):not(.avatar > *):not(.avatar__name > *):not(.mention)
 {
   background-position: center right;
   background-repeat: no-repeat;

--- a/websites/rushjs.io/docs/pages/news.md
+++ b/websites/rushjs.io/docs/pages/news.md
@@ -2,6 +2,8 @@
 title: What's new
 ---
 
+import { MastodonFeed } from 'theme-rushstack-suite-nav/lib/components/MastodonFeed';
+
 To find out what's changed in the latest release, please see the Rush
 [CHANGELOG.md](https://github.com/microsoft/rushstack/blob/main/apps/rush/CHANGELOG.md).
 
@@ -16,6 +18,6 @@ The **Rush Hour** monthly video call is the easiest way to find out what's happe
 
 ## Announcements
 
-Follow us on [Twitter (@rushstack)](https://twitter.com/rushstack) or [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack)
+Follow us on [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack) or [Twitter (@rushstack)](https://twitter.com/rushstack).
 
-<div dangerouslySetInnerHTML={{__html: '<a class="twitter-timeline" data-width="600" tweet-limit="10" chrome="noscrollbar" data-dnt="true" data-link-color="#c95228" href="https://twitter.com/rushstack?ref_src=twsrc%5Etfw">Tweets by @rushstack</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>'}} />
+<MastodonFeed mastodonUserFullName="@rushstack@fosstodon.org" mastodonUserId="109525862248474026" maxFeedItems="6" />

--- a/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/news.md
+++ b/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/news.md
@@ -2,8 +2,14 @@
 title: 最新动态
 ---
 
+import { MastodonFeed } from 'theme-rushstack-suite-nav/lib/components/MastodonFeed';
+
 通过 [CHANGELOG.md](https://github.com/microsoft/rushstack/blob/main/apps/rush/CHANGELOG.md) 来查看最新的更新。
 
 Rush 由 Rush Stack 的开发者社区维护。查看 [Rush Stack News](https://rushstack.io/pages/news/) 页面以获取最新的更新和路线图。
 
-这是 [@rushstack](https://twitter.com/rushstack) 的推特。
+## Announcements
+
+Follow us on [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack) or [Twitter (@rushstack)](https://twitter.com/rushstack).
+
+<MastodonFeed mastodonUserFullName="@rushstack@fosstodon.org" mastodonUserId="109525862248474026" maxFeedItems="6" />

--- a/websites/rushjs.io/src/css/custom.css
+++ b/websites/rushjs.io/src/css/custom.css
@@ -162,7 +162,7 @@ html[data-theme='dark'] blockquote {
  * We only do this inside an <article> element.  Use the class="no-external-link-icon" to disable it.
  * An "external" page has "://" in its URL and does not include a recognized DNS name.
  */
-article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon)
+article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon):not(.avatar > *):not(.avatar__name > *):not(.mention)
 {
   background-position: center right;
   background-repeat: no-repeat;

--- a/websites/rushstack.io/docs/pages/news.md
+++ b/websites/rushstack.io/docs/pages/news.md
@@ -31,4 +31,4 @@ of changelogs for all projects.
 
 Follow us on [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack) or [Twitter (@rushstack)](https://twitter.com/rushstack).
 
-<MastodonFeed mastodonUserFullName="@rushstack@fosstodon.org" mastodonUserId="109525862248474026" />
+<MastodonFeed mastodonUserFullName="@rushstack@fosstodon.org" mastodonUserId="109525862248474026" maxFeedItems="6" />

--- a/websites/rushstack.io/docs/pages/news.md
+++ b/websites/rushstack.io/docs/pages/news.md
@@ -2,6 +2,8 @@
 title: What's new
 ---
 
+import { MastodonFeed } from 'theme-rushstack-suite-nav/lib/components/MastodonFeed';
+
 The **Rush Hour** monthly video call is the easiest way to find out what's happening with Rush Stack:
 
 - Sign up using the [Events](https://rushstack.io/community/events/) page.
@@ -27,6 +29,6 @@ of changelogs for all projects.
 
 ## Announcements
 
-Follow us on [Twitter (@rushstack)](https://twitter.com/rushstack) or [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack)
+Follow us on [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack) or [Twitter (@rushstack)](https://twitter.com/rushstack).
 
-<div dangerouslySetInnerHTML={{__html: '<a class="twitter-timeline" data-width="600" tweet-limit="10" chrome="noscrollbar" data-dnt="true" data-link-color="#c95228" href="https://twitter.com/rushstack?ref_src=twsrc%5Etfw">Tweets by @rushstack</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>'}} />
+<MastodonFeed mastodonUserFullName="@rushstack@fosstodon.org" mastodonUserId="109525862248474026" />

--- a/websites/rushstack.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/news.md
+++ b/websites/rushstack.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/news.md
@@ -2,6 +2,8 @@
 title: What's new
 ---
 
+import { MastodonFeed } from 'theme-rushstack-suite-nav/lib/components/MastodonFeed';
+
 The **Rush Hour** monthly video call is the easiest way to find out what's happening with Rush Stack:
 
 - Sign up using the [Events](https://rushstack.io/community/events/) page.
@@ -27,6 +29,6 @@ of changelogs for all projects.
 
 ## Announcements
 
-Follow us on [Twitter (@rushstack)](https://twitter.com/rushstack) or [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack)
+Follow us on [Mastodon (@rushstack@fosstodon.org)](https://fosstodon.org/@rushstack) or [Twitter (@rushstack)](https://twitter.com/rushstack).
 
-<div dangerouslySetInnerHTML={{__html: '<a class="twitter-timeline" data-width="600" tweet-limit="10" chrome="noscrollbar" data-dnt="true" data-link-color="#c95228" href="https://twitter.com/rushstack?ref_src=twsrc%5Etfw">Tweets by @rushstack</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>'}} />
+<MastodonFeed mastodonUserFullName="@rushstack@fosstodon.org" mastodonUserId="109525862248474026" maxFeedItems="6" />

--- a/websites/rushstack.io/src/css/custom.css
+++ b/websites/rushstack.io/src/css/custom.css
@@ -163,7 +163,7 @@ html[data-theme='dark'] blockquote {
  * An "external" page has "://" in its URL and does not include a recognized DNS name.
  * The `:not(.avatar > *)` and `:not(.avatar__name > *)` exclusions are for blog author details.
  */
-article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon):not(.avatar > *):not(.avatar__name > *)
+article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon):not(.avatar > *):not(.avatar__name > *):not(.mention)
 {
   background-position: center right;
   background-repeat: no-repeat;

--- a/websites/tsdoc.org/src/css/custom.css
+++ b/websites/tsdoc.org/src/css/custom.css
@@ -149,7 +149,7 @@ html[data-theme='dark'] blockquote {
  * We only do this inside an <article> element.  Use the class="no-external-link-icon" to disable it.
  * An "external" page has "://" in its URL and does not include a recognized DNS name.
  */
-article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon)
+article a[href*="://"]:not([href*="api-extractor.com"]):not([href*="rushstack.io"]):not([href*="api.rushstack.io"]):not([href*="lfx.rushstack.io"]):not([href*="rushjs.io"]):not([href*="tsdoc.org"]):not([href*="localhost"]):not(.no-external-link-icon):not(.avatar > *):not(.avatar__name > *):not(.mention)
 {
   background-position: center right;
   background-repeat: no-repeat;


### PR DESCRIPTION
Twitter embedding has been broken for some time, and even when it worked, their control never looked very professional on our website.   Also it seems ***Twitter now blocks users from viewing your feed unless they log in.***  😆

This PR introduces a React component that can display our Mastodon feed inside a Docusaurus page.  

(I did look around for an existing library, but there aren't a lot of professional grade solutions. The implementation here is very loosely based on https://github.com/sampsyo/emfed/ )

Design goals
- Accurately reproduce the basic look & feel of the official Mastodon website in an embedded control
- Integrate cleanly with our Docusaurus theme including dark mode
- Securely render potentially untrusted server responses, using DOMPurify to scrub the content
- Reuse this component on the News page for all Rush Stack website projects

If this experiment is successful, we can eventually generalize the component and publish it to NPM, or contribute it back to an existing project such as `emfed`.

## Live page

https://rushstack.io/pages/news/

## Screenshot
<kbd>

![image](https://github.com/microsoft/rushstack-websites/assets/4673363/611bbfd3-12da-49ce-aeba-2cec7aa48d1f)

</kbd>
