### PR TITLE
Fix Header Alignment on Mobile and Dark Mode Visibility 

### DIFF
--- a/websites/rushjs.io/src/pages/index.tsx
+++ b/websites/rushjs.io/src/pages/index.tsx
@@ -27,7 +27,6 @@ const advocates: IAdvocate[] = [
 
 function AdvocateCard(props: { advocate: IAdvocate }): JSX.Element {
   const advocate: IAdvocate = props.advocate;
-  console.log(advocate);
   if (advocate.url) {
     const linkStyle = {
       color: 'inherit'

--- a/websites/rushjs.io/src/pages/index.tsx
+++ b/websites/rushjs.io/src/pages/index.tsx
@@ -27,16 +27,15 @@ const advocates: IAdvocate[] = [
 
 function AdvocateCard(props: { advocate: IAdvocate }): JSX.Element {
   const advocate: IAdvocate = props.advocate;
-
+  console.log(advocate);
   if (advocate.url) {
     const linkStyle = {
-      color: '#000000',
-      textDecorationColor: '#000000'
+      color: 'inherit'
     };
 
     return (
       <div className={styles.advocateCard}>
-        <Link style={linkStyle} to={advocate.url}>
+        <Link to={advocate.url} style={linkStyle}>
           <img src={`/images/3rdparty/${advocate.image}`} alt={`${advocate.title} logo`} />
           <div>{advocate.title}</div>
         </Link>
@@ -68,8 +67,8 @@ function CustomPage(props: {}): JSX.Element {
               </h2>
             </div>
           </div>
-          <div className="row" style={{ paddingTop: '2rem' }}>
-            <div style={{ marginLeft: 'auto', marginRight: '1rem' }}>
+          <div className="row" style={{ paddingTop: '2rem', justifyContent: 'center', gap: '2rem' }}>
+            <div>
               <Link
                 to="pages/intro/welcome"
                 className={['button', 'button--secondary', styles.mastheadButton].join(' ')}
@@ -77,7 +76,7 @@ function CustomPage(props: {}): JSX.Element {
                 <Translate id="home.masthead.learnMore">Learn More</Translate>
               </Link>
             </div>
-            <div style={{ marginRight: 'auto', marginLeft: '1rem' }}>
+            <div>
               <Link
                 to="pages/intro/get_started"
                 className={['button', 'button--primary', styles.mastheadButton].join(' ')}


### PR DESCRIPTION

## Changes Made

This PR addresses two issues:

1. **Header Alignment on Mobile View**: The header elements were misaligned on mobile devices, with one button on the left and another on the right. This PR fixes the alignment issue by centering the header elements horizontally on mobile devices.

2. **Dark Mode Visibility**: In dark mode, the company names listed in the "Who's using Rush?" section were displayed in black, making them nearly impossible to read against the dark background. This PR ensures that company names are displayed with a legible and contrasting color in both light and dark modes to improve accessibility and readability.

## Related Issues

- Header Alignment Issue: #205
- Dark Mode Visibility Issue: #206

## Screenshots (if applicable)

- Before Fix: ![image](https://github.com/microsoft/rushstack-websites/assets/85920362/6bf0bc73-69e0-4f26-a9f1-2ba34a4b21ae)
- After Fix:![image](https://github.com/microsoft/rushstack-websites/assets/85920362/2a8faf38-aa3a-4402-b3b6-b464231262c6)

- Before Fix:![image](https://github.com/microsoft/rushstack-websites/assets/85920362/94692388-c16c-4392-aca8-a68096cfc79d)
- After Fix:
![image](https://github.com/microsoft/rushstack-websites/assets/85920362/ab6926dd-886d-41da-a935-92f355af37be)

## Testing Done

- Tested the changes on various mobile devices to ensure header alignment is correct.
- Verified the visibility of company names in both light and dark modes.

This PR resolves the reported issues and enhances the user experience by improving the header alignment on mobile devices and ensuring better visibility in dark mode.
