### PR TITLE
Update cobuilds.md

### DIFF
--- a/websites/rushjs.io/docs/pages/maintainer/cobuilds.md
+++ b/websites/rushjs.io/docs/pages/maintainer/cobuilds.md
@@ -366,7 +366,7 @@ Some examples:
 <!-- prettier-ignore-start -->
 | CI system | Suggested value for `RUSH_COBUILD_CONTEXT_ID` |
 |---|---|
-| [Azure DevOps](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number?view=azure-devops&tabs=yaml) | `$(Build.BuildNumber)_$(System.Attempt)` |
+| [Azure DevOps](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number?view=azure-devops&tabs=yaml) | `$(Build.BuildNumber)_$(System.JobAttempt)` |
 | [CircleCI](https://circleci.com/docs/variables/) | `${CIRCLE_WORKFLOW_ID}_${CIRCLE_WORKFLOW_JOB_ID}` |
 | [GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) | ` ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}` |
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
Minor fix. On Azure, the attempt number is available through `System.JobAttempt` not `System.Attempt`. See: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services