### PR TITLE
[rush] add zsh guide for tab completion

### DIFF
--- a/websites/rushjs.io/docs/pages/developer/tab_completion.md
+++ b/websites/rushjs.io/docs/pages/developer/tab_completion.md
@@ -72,7 +72,7 @@ complete rush -x -a "(__fish_rush)"
 
 ## Zsh
 
-[Zsh](https://www.zsh.org/) has slightly different env variables, add the following into `~/.zshrc`:
+[Zsh](https://www.zsh.org/) has slightly different env variables, add the following into **~/.zshrc**:
 
 ```zsh
 (( ${+commands[rush]} )) && {

--- a/websites/rushjs.io/docs/pages/developer/tab_completion.md
+++ b/websites/rushjs.io/docs/pages/developer/tab_completion.md
@@ -69,3 +69,18 @@ end
 
 complete rush -x -a "(__fish_rush)"
 ```
+
+## Zsh
+
+[Zsh](https://www.zsh.org/) has slightly different env variables, add the following into `~/.zshrc`:
+
+```zsh
+(( ${+commands[rush]} )) && {
+  _rush_completion() {
+    compadd -- $(rush tab-complete --position ${CURSOR} --word "${BUFFER}" 2>>/dev/null)
+  }
+  compdef _rush_completion rush
+}
+```
+
+It checks for the existence of rush. This needs to be added after the PATH is properly set (or after [nvm](https://github.com/nvm-sh/nvm) is initialized). Otherwise, you will need to remove the first line.

--- a/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/developer/tab_completion.md
+++ b/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/developer/tab_completion.md
@@ -47,3 +47,18 @@ _rush_bash_complete()
 
 complete -f -F _rush_bash_complete rush
 ```
+
+## Zsh
+
+[Zsh](https://www.zsh.org/) 的环境变量会稍有不同，需要在 `~/.zshrc` 文件中添加以下代码：
+
+```zsh
+(( ${+commands[rush]} )) && {
+  _rush_completion() {
+    compadd -- $(rush tab-complete --position ${CURSOR} --word "${BUFFER}" 2>>/dev/null)
+  }
+  compdef _rush_completion rush
+}
+```
+
+它会检查 rush 命令是否存在，因此这段代码需要添加在 PATH 已经设置好之后（或者在 [nvm](https://github.com/nvm-sh/nvm) 初始化之后）。或者，你也可以删除第一行的 rush 命令检查。

--- a/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/developer/tab_completion.md
+++ b/websites/rushjs.io/i18n/zh-cn/docusaurus-plugin-content-docs/current/pages/developer/tab_completion.md
@@ -50,7 +50,7 @@ complete -f -F _rush_bash_complete rush
 
 ## Zsh
 
-[Zsh](https://www.zsh.org/) 的环境变量会稍有不同，需要在 `~/.zshrc` 文件中添加以下代码：
+[Zsh](https://www.zsh.org/) 的环境变量会稍有不同，需要在 **~/.zshrc** 文件中添加以下代码：
 
 ```zsh
 (( ${+commands[rush]} )) && {


### PR DESCRIPTION
The bash approach doesn't work for zsh as `COMP_POINT` is not defined, using `CURSOR` instead.