### PR TITLE
[rush] Add a "Compatibility matrix" documenting supported versions of Node/PNPM/etc

### DIFF
--- a/websites/rushjs.io/docs/pages/maintainer/compatibility_matrix.md
+++ b/websites/rushjs.io/docs/pages/maintainer/compatibility_matrix.md
@@ -1,0 +1,41 @@
+---
+title: Compatibility matrix
+---
+
+## "Supported" ranges
+
+| Rush version | Node.js version                             | PNPM version             | Git version |
+| ------------ | ------------------------------------------- | ------------------------ | ----------- |
+| `5.122.0`    | `^16.20.0` <br/> `^18.18.0` <br/> `^20.9.0` | `^7.33.5` <br/> `^8.7.6` | `^2.26.3`   |
+
+## Associated source code constants
+
+| Variable                             | Current Value | Source file                                                                                                                    | Description                                                                                                                                                                                     |
+| ------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MINIMUM_SUPPORTED_NPM_VERSION`      | `'4.5.0'`     | [SetupChecks.ts](https://github.com/microsoft/rushstack/blob/main/libraries/rush-lib/src/logic/SetupChecks.ts)                 | Rush fails if the NPM versions older than this version                                                                                                                                          |
+| `MINIMUM_SUPPORTED_PNPM_VERSION`     | `'5.0.0'`     | [SetupChecks.ts](https://github.com/microsoft/rushstack/blob/main/libraries/rush-lib/src/logic/SetupChecks.ts)                 | Rush fails if the PNPM versions older than this version                                                                                                                                         |
+| `UPCOMING_NODE_LTS_VERSION`          | `20`          | [NodeJsCompatibility.ts](https://github.com/microsoft/rushstack/blob/main/libraries/rush-lib/src/logic/NodeJsCompatibility.ts) | This constant is the major version of the next LTS node Node.js release.                                                                                                                        |
+| `reportAncientIncompatibleVersion()` | `'<14.18.0'`  | [NodeJsCompatibility.ts](https://github.com/microsoft/rushstack/blob/main/libraries/rush-lib/src/logic/NodeJsCompatibility.ts) | Used to report when the Node.js version is known to have serious incompatibilities. In that situation, the user should downgrade Rush to an older release that supported their Node.js version. |
+
+## Node.js CI validation
+
+Rush Stack's continuous integration currently builds:
+
+[rushstack/.github/workflows/ci.yml](https://github.com/microsoft/rushstack/blob/main/.github/workflows/ci.yml)
+
+```yaml
+matrix:
+  include:
+    - NodeVersion: 16.20.x
+      NodeVersionDisplayName: 16
+      OS: ubuntu-latest
+    - NodeVersion: 18.18.x
+      NodeVersionDisplayName: 18
+      OS: ubuntu-latest
+    - NodeVersion: 20.9.x
+      NodeVersionDisplayName: 20
+      OS: ubuntu-latest
+    - NodeVersion: 18.18.x
+      NodeVersionDisplayName: 18
+      OS: windows-latest
+```

--- a/websites/rushjs.io/sidebars.js
+++ b/websites/rushjs.io/sidebars.js
@@ -56,7 +56,8 @@ const sidebars = {
         'pages/maintainer/phased_builds',
         'pages/maintainer/cobuilds',
         'pages/maintainer/npm_registry_auth',
-        'pages/maintainer/custom_tips'
+        'pages/maintainer/custom_tips',
+        'pages/maintainer/compatibility_matrix'
       ]
     },
     {


### PR DESCRIPTION
PNPM 9 was released recently, but Rush doesn't support it yet. 

For a person who's trying to set up a new Rush repo, how are they supposed to know that?  Rush itself can print some warnings, but let's also try to document the supported/recommended versions of important tooling.