### PR TITLE
Update documentation for `extends` to mention use of `null`

### DIFF
--- a/websites/heft.rushstack.io/docs/pages/advanced/heft-config-file.md
+++ b/websites/heft.rushstack.io/docs/pages/advanced/heft-config-file.md
@@ -10,6 +10,7 @@ library is the standard engine used to load Heft's config files. It provides a n
 - Support for [rig package](../intro/rig_packages.md) resolution
 - Four different `"extends"` inheritance types (append, merge, replace, computed) with preconfigured defaults
 - Property inheritance directives to customize them
+- Ability to delete a setting inherited from the parent by specifying `null` as the new value
 
 ## Property inheritance directives
 

--- a/websites/heft.rushstack.io/docs/pages/configs/api-extractor-task_json.md
+++ b/websites/heft.rushstack.io/docs/pages/configs/api-extractor-task_json.md
@@ -25,6 +25,8 @@ title: api-extractor-task.json
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   * 
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/api-extractor-task.json",
 

--- a/websites/heft.rushstack.io/docs/pages/configs/heft_json.md
+++ b/websites/heft.rushstack.io/docs/pages/configs/heft_json.md
@@ -22,6 +22,8 @@ title: heft.json
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   * 
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/heft.json",
 

--- a/websites/heft.rushstack.io/docs/pages/configs/node-service_json.md
+++ b/websites/heft.rushstack.io/docs/pages/configs/node-service_json.md
@@ -23,6 +23,8 @@ title: node-service.json
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   * 
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/serve-command.json",
 

--- a/websites/heft.rushstack.io/docs/pages/configs/sass_json.md
+++ b/websites/heft.rushstack.io/docs/pages/configs/sass_json.md
@@ -22,6 +22,8 @@ title: sass.json
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   * 
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/serve-command.json",
 

--- a/websites/heft.rushstack.io/docs/pages/configs/typescript_json.md
+++ b/websites/heft.rushstack.io/docs/pages/configs/typescript_json.md
@@ -22,6 +22,8 @@ title: typescript.json
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   * 
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/typescript.json",
 

--- a/websites/rushjs.io/docs/pages/configs/rush-project_json.md
+++ b/websites/rushjs.io/docs/pages/configs/rush-project_json.md
@@ -18,6 +18,8 @@ by a [rig package](https://rushstack.io/pages/heft/rig_packages/).
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "my-rig/profiles/default/config/rush-project.json",
 


### PR DESCRIPTION
Updates the docs about `heft-config-file` and the comments in the template files to mention that when extending from another file, you can delete an inherited setting by setting it to `null` in the current file.